### PR TITLE
Updated install script to work with openDsh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,8 +22,10 @@ OS_RELEASE_FILE="/etc/os-release"
 
 if grep -q "Raspbian" ${OS_RELEASE_FILE}; then
   installArgs="-DRPI_BUILD=true"
+  isRpi=true
 else
-  installArgs="-DRPI_BUILD=false"
+  installArgs=""
+  isRpi=false
 fi
 
 #check to see if there are any arguments supplied, if none are supplied run full install
@@ -286,13 +288,15 @@ else
   cd ..
 
   #Make ilclient
-  echo making ilclient
-  make /opt/vc/src/hello_pi/libs/ilclient
-  if [[ $? -eq 0 ]]; then
-    echo -e ilclient make ok'\n'
-  else
-    echo Error making ilclient check logs
-    exit
+  if $isRpi; then
+    echo making ilclient
+    make /opt/vc/src/hello_pi/libs/ilclient
+    if [[ $? -eq 0 ]]; then
+      echo -e ilclient make ok'\n'
+    else
+      echo Error making ilclient check logs
+      exit
+    fi
   fi
 
   echo -e cloning openauto'\n'

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,53 @@
 #!/bin/bash
+echo "Running apt update"
+
+#set default arguments
+deps=false
+aasdk=false
+gstreamer=false
+openauto=false
+dash=false
+perms=false
+
+if [ $# -gt 0 ]; then
+    while [ "$1" != "" ]; do
+        case $1 in
+            --deps )           shift
+                                    deps=true
+                                    ;;
+            --aasdk )           aasdk=true
+                                    ;;
+            --gstreamer )       gstreamer=true
+                                    ;;
+            --openauto )       openauto=true
+                                    ;;
+            --dash )           dash=true
+                                    ;;
+            --perms )          perms=true
+                                    ;;
+            -h | --help )           usage
+                                    exit
+                                    ;;
+            * )                     usage
+                                    exit 1
+        esac
+        shift
+    done
+
+else
+    echo "Your command line contains no arguments"
+    deps=true
+    aasdk=true
+    gstreamer=true
+    openauto=true
+    dash=true
+    perms=true
+fi
+
+
 
 #Array of dependencies any new dependencies can be added here
-deps=(
+dependencies=(
 "alsa-utils"
 "cmake"
 "libboost-all-dev"
@@ -22,86 +68,340 @@ deps=(
 "librtaudio6"
 "libkf5bluezqt-dev"
 "libtag1-dev"
+"qml-module-qtquick2"
+"doxygen"
+"qml-module-qtquick*"
+"libglib2.0-dev"
+"libgstreamer1.0-dev"
+"gstreamer1.0-plugins-base-apps"
+"gstreamer1.0-plugins-bad"
+"gstreamer1.0-libav"
+"gstreamer1.0-alsa"
+"libgstreamer-plugins-base1.0-dev"
+"qtdeclarative5-dev"
+"qt5-default"
+"libgstreamer-plugins-bad1.0-dev"
+"libunwind-dev"
+"qml-module-qtmultimedia"
 )
 
-#loop through dependencies and install
-for app in ${deps[@]}; do
-	echo "installing: " $app
-	sudo apt -qq -o=Dpkg::Use-Pty=0 install $app -y > /dev/null 2> /dev/null
+###############################  dependencies  #########################
+if [ "$deps" = true ]; then
+  #loop through dependencies and install
+	echo "installing dependencies"
+  for app in ${dependencies[@]}; do
+    echo "installing: " $app
+    sudo apt -qq -o=Dpkg::Use-Pty=0 install $app -y > /dev/null 2> /dev/null
 
-	if [[ $? > 0 ]]
-	then
-	    echo $app " Failed to install, quitting"
-	    exit
-	else
-	    echo $app " Installed ok"
-	    echo
-	    
-	fi
-done
-
-echo "All dependencies installed"
-echo
-
-#make ilclient
-echo "making ilclient"
-make /opt/vc/src/hello_pi/libs/ilclient
-if [[ $? > 0 ]]
-  then
-    echo "unable to make ilclient"
-  exit
-else
-  echo "made ok"
+    if [[ $? > 0 ]]
+      then
+          echo $app " Failed to install, quitting"
+          exit
+      else
+          echo $app " Installed ok"
+          echo
+    fi
+  done
+  echo "All dependencies installed"
   echo
-fi
-
-#begin cmake
-echo "beginning cmake for raspberry pi"
-cmake -DRPI_BUILD=TRUE -DGST_BUILD=TRUE -DCMAKE_BUILD_TYPE=Release . 
-if [[ $? > 0 ]]
-  then
-    echo "Cmake error"
-  exit
 else
-  echo "Cmake ok"
-  echo #####
+	echo "skipping dependencies"
 fi
 
-#start make
-echo "beginning make, this will take a while"
-make
-if [[ $? > 0 ]]
-  then
-    echo "make error check output above"
+
+###############################  AASDK #########################
+if [ "$aasdk" = true ]; then
+  #change to parent directory
+  cd ..
+
+  #clone aasdk
+  git clone https://github.com/OpenDsh/aasdk
+  if [[ $? > 0 ]]
+      then
+        cd aasdk
+        if [[ $? > 0 ]]
+          then
+            echo "clone/pull error"
+          exit
+        else
+          git pull https://github.com/OpenDsh/aasdk
+          echo "cloned OK"
+          cd ..
+          echo
+        fi
+  else
+    echo "cloned ok"
+    echo
+  fi
+
+  #change into aasdk folder
+  echo "moving to aasdk"
+  cd aasdk
+
+  #beginning cmake
+  cmake -DCMAKE_BUILD_TYPE=Release .
+  if [[ $? > 0 ]]
+    then
+      echo "CMake error check logs"
     exit
   else
-    echo "make ok, executable can be found ../bin/ia"
+    echo "Cmake ok"
     echo
+  fi
 
-    #check if usb rules exist
-    echo "checking if permissions exist"
+  #beginning make
+  make -j2
 
-    #udev rule to be created below, change as needed
-    FILE=/etc/udev/rules.d/51-iadash.rules
-    if [[ -f "$FILE" ]]
-      then
-        echo "rules exists"
-        echo
-      else
-        sudo touch $FILE
+  if [[ $? > 0 ]]
+    then
+      echo "make error check logs"
+    exit
+  else
+    echo "make ok"
+    echo
+  fi
 
-        # OPEN USB RULE, CREATE MORE SECURE RULE IF REQUIRED
-        echo "SUBSYSTEM==\"usb\", ATTR{idVendor}==\"*\", ATTR{idProduct}==\"*\", MODE=\"0660\", GROUP=\"plugdev\"" | sudo tee $FILE
-      if [[ $? > 0 ]]
-        then
-          echo "unable to create permissions"
-        else
-          echo "permissions created"
-      fi
-    fi
+  #begin make install
+  sudo make install
+
+  if [[ $? > 0 ]]
+    then
+      echo "install error check logs"
+    exit
+  else
+    echo "installed ok ok"
+    echo
+  fi
+  cd ../dash
+else
+	echo "skipping aasdk"
 fi
 
-#Start app
-echo "starting app"
-cd ../bin
-./ia
+
+###############################  gstreamer  #########################
+#check if gstreamer install is requested
+if [ "$gstreamer" = true ]; then
+  echo "installing gstreamer"
+  #change to parent directory
+  cd ..
+  #clone gstreamer
+  echo "Cloning Gstreamer"
+  git clone git://anongit.freedesktop.org/gstreamer/qt-gstreamer
+  if [[ $? > 0 ]]
+    then
+      cd qt-gstreamer
+      if [[ $? > 0 ]]
+        then
+          echo "clone/pull error"
+        exit
+      else
+        git pull git://anongit.freedesktop.org/gstreamer/qt-gstreamer
+        echo "cloned OK"
+        cd ..
+        echo
+      fi
+  else
+    echo "cloned OK"
+    echo
+  fi
+
+  #change into newly cloned directory
+  cd qt-gstreamer
+
+  #create build directory
+  echo "creating Gstreamer build directory"
+
+  mkdir build
+
+  if [[ $? > 0 ]]
+    then
+      echo "unable to create Gstreamer build directory assuming it exists..."
+  else
+    echo "build directory made"
+    echo
+  fi
+
+  cd build
+
+  #run cmake
+  echo "beginning cmake"
+
+  cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH) -DCMAKE_INSTALL_INCLUDEDIR=include -DQT_VERSION=5 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-std=c++11
+
+  if [[ $? > 0 ]]
+    then
+      echo "cmake failed"
+    exit
+  else
+    echo "make ok"
+    echo
+  fi
+
+  #make j4
+  echo "making J4"
+  make -j4
+
+  if [[ $? > 0 ]]
+    then
+      echo "make error check logs"
+    exit
+  else
+    echo "make ok"
+    echo
+  fi
+
+  #run make install
+  echo "beginning make install"
+  sudo make install
+
+  if [[ $? > 0 ]]
+    then
+      echo "install error check logs"
+    exit
+  else
+    echo "installed ok"
+    echo
+  fi
+
+  #run ldconfig
+  sudo ldconfig
+  cd ../../dash
+
+else
+	echo "skipping gstreamer"
+fi
+
+
+
+###############################  openauto  #########################
+if [ "$openauto" = true ]; then
+  echo "installing openauto"
+  cd ..
+
+  clone openauto
+  git clone https://github.com/openDsh/openauto.git
+  if [[ $? > 0 ]]
+    then
+      cd openauto
+      if [[ $? > 0 ]]
+        then
+          echo "clone/pull error"
+        exit
+      else
+        git pull https://github.com/openDsh/openauto.git
+        echo "cloned OK"
+        cd ..
+        echo
+      fi
+  else
+    echo "cloned OK"
+    echo
+  fi
+
+  cd openauto
+
+  #beginning cmake
+  cmake -DRPI_BUILD=true -DGST_BUILD=true
+  if [[ $? > 0 ]]
+    then
+      echo "cmake error check logs"
+    exit
+  else
+    echo "cmake OK"
+    echo
+  fi
+
+  #beginning cmake
+  make
+  if [[ $? > 0 ]]
+    then
+      echo "make error check logs"
+    exit
+  else
+    echo "make OK"
+    echo
+  fi
+
+  #run make install
+  echo "beginning make install"
+  sudo make install
+  if [[ $? > 0 ]]
+    then
+      echo "install error check logs"
+    exit
+  else
+    echo "installed ok"
+    echo
+  fi
+  cd ../dash
+else
+	echo "skipping openauto"
+fi
+
+
+###############################  dash  #########################
+if [ "$dash" = true ]; then
+  #loop through dependencies and install
+	echo "installing dash"
+  echo "making ilclient"
+  make /opt/vc/src/hello_pi/libs/ilclient
+  if [[ $? > 0 ]]
+    then
+      echo "error making ilclient check logs"
+    exit
+  else
+    echo "make ok"
+    echo
+  fi
+
+  echo "running cmake for dash"
+  cmake -DRPI_BUILD=TRUE -DGST_BUILD=TRUE .
+  if [[ $? > 0 ]]
+    then
+      echo "cmake error check logs"
+    exit
+  else
+    echo "cmake OK"
+    echo
+  fi
+
+  echo "running make"
+  make
+  if [[ $? > 0 ]]
+    then
+      echo "make error check output above"
+      exit
+    else
+      echo "make ok, executable can be found ../bin/ia"
+      echo
+
+      #check if usb rules exist
+      echo "checking if permissions exist"
+
+      #udev rule to be created below, change as needed
+      FILE=/etc/udev/rules.d/51-iadash.rules
+      if [[ -f "$FILE" ]]
+        then
+          echo "rules exists"
+          echo
+        else
+          sudo touch $FILE
+
+          # OPEN USB RULE, CREATE MORE SECURE RULE IF REQUIRED
+          echo "SUBSYSTEM==\"usb\", ATTR{idVendor}==\"*\", ATTR{idProduct}==\"*\", MODE=\"0660\", GROUP=\"plugdev\"" | sudo tee $FILE
+        if [[ $? > 0 ]]
+          then
+            echo "unable to create permissions"
+          else
+            echo "permissions created"
+        fi
+      fi
+  fi
+
+  #Start app
+  echo "starting app"
+  cd bin
+  ./ia
+else
+	echo "skipping dash"
+fi

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 #repo addresses
 aasdkRepo="https://github.com/OpenDsh/aasdk"
 gstreamerRepo="git://anongit.freedesktop.org/gstreamer/qt-gstreamer"
-openautoRepo="https://github.com/openDsh/openauto.git"
+openautoRepo="https://github.com/openDsh/openauto"
 
 #Help text
 display_help() {
@@ -37,7 +37,6 @@ if [ $# -gt 0 ]; then
   gstreamer=false
   openauto=false
   dash=false
-  perms=false
     while [ "$1" != "" ]; do
         case $1 in
             --deps )           shift
@@ -50,8 +49,6 @@ if [ $# -gt 0 ]; then
             --openauto )       openauto=true
                                     ;;
             --dash )           dash=true
-                                    ;;
-            --perms )          perms=true
                                     ;;
             -h | --help )           display_help
                                     exit
@@ -68,7 +65,6 @@ else
     gstreamer=true
     openauto=true
     dash=true
-    perms=true
 fi
 
 #Array of dependencies any new dependencies can be added here
@@ -163,8 +159,19 @@ else
   echo -e moving to aasdk '\n'
   cd aasdk
 
+  echo -e Making AASDK build directory '\n'
+
+  mkdir build
+  if [[ $? -eq 0 ]]; then
+    echo -e AASDK build directory made
+  else
+    echo Unable to create AASDK build directory assuming it exists...
+  fi
+
+  cd build
+
   #beginning cmake
-  cmake -DCMAKE_BUILD_TYPE=Release .
+  cmake -DCMAKE_BUILD_TYPE=Release ../
   if [[ $? -eq 0 ]]; then
       echo -e Aasdk CMake completed successfully'\n'
   else
@@ -285,18 +292,6 @@ else
   echo Installing openauto
   cd ..
 
-  #Make ilclient
-  if $isRpi; then
-    echo making ilclient
-    make /opt/vc/src/hello_pi/libs/ilclient
-    if [[ $? -eq 0 ]]; then
-      echo -e ilclient make ok'\n'
-    else
-      echo Error making ilclient check logs
-      exit
-    fi
-  fi
-
   echo -e cloning openauto'\n'
   git clone $openautoRepo
   if [[ $? -eq 0 ]]; then
@@ -315,8 +310,19 @@ else
 
   cd openauto
 
+  echo -e Making openauto build directory '\n'
+
+  mkdir build
+  if [[ $? -eq 0 ]]; then
+    echo -e openauto build directory made
+  else
+    echo Unable to create openauto build directory assuming it exists...
+  fi
+
+  cd build
+
   echo Beginning openauto cmake
-  cmake ${installArgs} -DGST_BUILD=true
+  cmake ${installArgs} -DGST_BUILD=true ../
   if [[ $? -eq 0 ]]; then
     echo -e Openauto CMake OK'\n'
   else

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
-echo "Running apt update"
+
+#repo addresses
+aasdkRepo="https://github.com/OpenDsh/aasdk"
+gstreamerRepo="git://anongit.freedesktop.org/gstreamer/qt-gstreamer"
+openautoRepo="https://github.com/rhysmorgan134/openauto.git"
+
+#Help text
+display_help() {
+    echo
+    echo "   --deps           install all dependencies"
+    echo "   --aasdk          install and build aasdk"
+    echo "   --openauto       install and build openauto "
+    echo "   --gstreamer      install and build gstreamer "
+    echo "   --dash           install and build dash "
+    echo
+    exit 1
+}
 
 #set default arguments
 deps=false
@@ -25,17 +41,17 @@ if [ $# -gt 0 ]; then
                                     ;;
             --perms )          perms=true
                                     ;;
-            -h | --help )           usage
+            -h | --help )           display_help
                                     exit
                                     ;;
-            * )                     usage
+            * )                     display_help
                                     exit 1
         esac
         shift
     done
 
 else
-    echo "Running Full install"
+    echo "Full install running"
     deps=true
     aasdk=true
     gstreamer=true
@@ -89,6 +105,8 @@ dependencies=(
 if [ "$deps" = true ]; then
   #loop through dependencies and install
 	echo "installing dependencies"
+	echo "Running apt update"
+	sudo apt update
   for app in ${dependencies[@]}; do
     echo "installing: " $app
     sudo apt -qq -o=Dpkg::Use-Pty=0 install $app -y > /dev/null 2> /dev/null
@@ -115,7 +133,7 @@ if [ "$aasdk" = true ]; then
   cd ..
 
   #clone aasdk
-  git clone https://github.com/OpenDsh/aasdk
+  git clone $aasdkRepo
   if [[ $? > 0 ]]
       then
         cd aasdk
@@ -124,7 +142,7 @@ if [ "$aasdk" = true ]; then
             echo "clone/pull error"
           exit
         else
-          git pull https://github.com/OpenDsh/aasdk
+          git pull $aasdkRepo
           echo "cloned OK"
           cd ..
           echo
@@ -186,7 +204,7 @@ if [ "$gstreamer" = true ]; then
   cd ..
   #clone gstreamer
   echo "Cloning Gstreamer"
-  git clone git://anongit.freedesktop.org/gstreamer/qt-gstreamer
+  git clone $gstreamerRepo
   if [[ $? > 0 ]]
     then
       cd qt-gstreamer
@@ -195,7 +213,7 @@ if [ "$gstreamer" = true ]; then
           echo "clone/pull error"
         exit
       else
-        git pull git://anongit.freedesktop.org/gstreamer/qt-gstreamer
+        git pull gstreamerRepo
         echo "cloned OK"
         cd ..
         echo
@@ -279,7 +297,7 @@ if [ "$openauto" = true ]; then
   cd ..
 
   clone openauto
-  git clone https://github.com/openDsh/openauto.git
+  git clone $openautoRepo
   if [[ $? > 0 ]]
     then
       cd openauto
@@ -288,7 +306,7 @@ if [ "$openauto" = true ]; then
           echo "clone/pull error"
         exit
       else
-        git pull https://github.com/openDsh/openauto.git
+        git pull $openautoRepo
         echo "cloned OK"
         cd ..
         echo

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 #repo addresses
 aasdkRepo="https://github.com/OpenDsh/aasdk"
 gstreamerRepo="git://anongit.freedesktop.org/gstreamer/qt-gstreamer"
-openautoRepo="https://github.com/rhysmorgan134/openauto.git"
+openautoRepo="https://github.com/openDsh/openauto.git"
 
 #Help text
 display_help() {

--- a/install.sh
+++ b/install.sh
@@ -213,7 +213,7 @@ if [ $gstreamer = true ]; then
   else
     cd qt-gstreamer
       if [[ $? -eq 0 ]]; then
-        git pull gstreamerRepo
+        git pull $gstreamerRepo
         echo -e cloned OK '\n'
         cd ..
       else

--- a/install.sh
+++ b/install.sh
@@ -17,9 +17,10 @@ display_help() {
     exit 1
 }
 
-#TODO test on non raspbian build
+#location of OS details for linux
 OS_RELEASE_FILE="/etc/os-release"
 
+#check if Raspian is in the file, if not set the install Args to be false
 if grep -q "Raspbian" ${OS_RELEASE_FILE}; then
   installArgs="-DRPI_BUILD=true"
   isRpi=true
@@ -93,8 +94,6 @@ dependencies=(
 "libkf5bluezqt-dev"
 "libtag1-dev"
 "qml-module-qtquick2"
-#TODO delete below after test
-#"qml-module-qtquick*"
 "libglib2.0-dev"
 "libgstreamer1.0-dev"
 "gstreamer1.0-plugins-base-apps"
@@ -119,7 +118,7 @@ if [ $deps = false ]
     echo Running apt update
     sudo apt update
 
-    installString="sudo apt install "
+    installString="sudo apt install -y "
 
     #create apt install string
     for i in ${dependencies[@]}; do
@@ -127,7 +126,6 @@ if [ $deps = false ]
     done
 
     #run install
-    echo ${installString}
     ${installString}
     if [[ $? -eq 0 ]]; then
         echo -e All dependencies Installed ok '\n'
@@ -387,6 +385,27 @@ else
       echo Dash make failed with error code $?
       exit
   fi
+
+  #Setting openGL driver and GPU memory to 256mb
+  if $isRpi; then
+    sudo raspi-config nonint do_memory_split 256
+    if [[ $? -eq 0 ]]; then
+      echo -e Memory set to 256mb'\n'
+    else
+      echo Setting memory failed with error code $? please set manually
+      exit
+    fi
+
+    sudo raspi-config nonint do_gldriver G2
+    if [[ $? -eq 0 ]]; then
+      echo -e OpenGL set ok'\n'
+    else
+      echo Setting openGL failed with error code $? please set manually
+      exit
+    fi
+
+  fi
+
 
   #Start app
   echo Starting app

--- a/install.sh
+++ b/install.sh
@@ -350,9 +350,19 @@ fi
 if [ $dash = false ]; then
 	echo -e Skipping dash'\n'
 else
+
+  mkdir build
+  if [[ $? -eq 0 ]]; then
+    echo -e dash build directory made
+  else
+    echo Unable to create dash build directory assuming it exists...
+  fi
+
+  cd build
+
 	echo -e Installing dash'\n'
   echo Running CMake for dash
-  cmake ${installArgs} -DGST_BUILD=TRUE .
+  cmake ${installArgs} -DGST_BUILD=TRUE ../
   if [[ $? -eq 0 ]]; then
     echo -e Dash CMake OK'\n'
   else
@@ -409,6 +419,6 @@ else
 
   #Start app
   echo Starting app
-  cd bin
+  cd ../bin
   ./ia
 fi

--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,7 @@ if [ $# -gt 0 ]; then
     done
 
 else
-    echo "Your command line contains no arguments"
+    echo "Running Full install"
     deps=true
     aasdk=true
     gstreamer=true


### PR DESCRIPTION
Script now beings in dash, then clones the 3 required directories as peers of dash. Then runs through the process to install them all. Added arguments to choose what part of the script will run

* no options will run a full install of all of the below
* --deps - will install dependencies
* --aasdk - will install aasdk
* --gstreamer - will install gstreamer
* --openauto - will install open auto
* --dash - will install dash

example will only install dependencies, openauto and dash.
```./install.sh --deps --openauto --dash```