### PR TITLE
Add build dir for aasdk and openauto in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -159,8 +159,20 @@ else
   echo -e moving to aasdk '\n'
   cd aasdk
 
+  #create build directory
+  echo Creating aasdk build directory
+  mkdir build
+
+  if [[ $? -eq 0 ]]; then
+    echo -e aasdk build directory made
+  else
+    echo Unable to create aasdk build directory assuming it exists...
+  fi
+
+  cd build
+
   #beginning cmake
-  cmake -DCMAKE_BUILD_TYPE=Release
+  cmake -DCMAKE_BUILD_TYPE=Release ../
   if [[ $? -eq 0 ]]; then
       echo -e Aasdk CMake completed successfully'\n'
   else
@@ -189,7 +201,7 @@ else
     echo Aasdk install failed with code $?
     exit
   fi
-  cd ../dash
+  cd ../../dash
 fi
 
 
@@ -222,7 +234,7 @@ if [ $gstreamer = true ]; then
   cd qt-gstreamer
 
   #create build directory
-  echo creating Gstreamer build directory
+  echo Creating Gstreamer build directory
   mkdir build
 
   if [[ $? -eq 0 ]]; then
@@ -299,10 +311,20 @@ else
 
   cd openauto
 
+  #create build directory
+  echo Creating openauto build directory
+  mkdir build
   
+  if [[ $? -eq 0 ]]; then
+    echo -e openauto build directory made
+  else
+    echo Unable to create openauto build directory assuming it exists...
+  fi
+
+  cd build
 
   echo Beginning openauto cmake
-  cmake ${installArgs} -DGST_BUILD=true
+  cmake ${installArgs} -DGST_BUILD=true ../
   if [[ $? -eq 0 ]]; then
     echo -e Openauto CMake OK'\n'
   else
@@ -328,7 +350,7 @@ else
     echo Openauto make install failed with error code $?
     exit
   fi
-  cd ../dash
+  cd ../../dash
 fi
 
 
@@ -337,7 +359,10 @@ if [ $dash = false ]; then
 	echo -e Skipping dash'\n'
 else
 
+  #create build directory
+  echo Creating dash build directory
   mkdir build
+
   if [[ $? -eq 0 ]]; then
     echo -e dash build directory made
   else


### PR DESCRIPTION
## Change Log
- Adds `build/` directory for building [aasdk](https://github.com/openDsh/aasdk) and [openauto](https://github.com/openDsh/openauto) in `install.sh`

## Description
Feel free to close this PR if there is a valid reason not to have this.
Based on some searching it seems this did exist before at one point as it was introduced in the commit https://github.com/openDsh/dash/pull/6/commits/5b2aec930c1622afc87b4931814f296dd46e58a5 as part of the PR https://github.com/openDsh/dash/pull/6 but then was later removed in https://github.com/openDsh/dash/pull/12 but doesn't have any explanation of why, so if there is a reason then I'd like for this PR to at least serve as documentation for why that is.

However, I have tested the install script with these changes have been using it to make it easier to recompile openauto by clearing its build directory after making environmental changes.
I haven't run into any issues but also only have one environment to test in so if some others can test it out that would be great.

## Checklist:
  - [x] The code change is tested and works locally.