### PR TITLE
install.sh - exit with error on failture

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -127,7 +127,7 @@ if [ $deps = false ]
         echo -e All dependencies Installed ok '\n'
     else
         echo Package failed to install with error code $?, quitting check logs above
-        exit
+        exit 1
     fi
 fi
 
@@ -151,7 +151,7 @@ else
       cd ..
     else
       echo Aasdk clone/pull error
-      exit
+      exit 1
     fi
   fi
 
@@ -177,7 +177,7 @@ else
       echo -e Aasdk CMake completed successfully'\n'
   else
     echo Aasdk CMake failed with code $?
-    exit
+    exit 1
   fi
 
   #beginning make
@@ -187,7 +187,7 @@ else
     echo -e Aasdk Make completed successfully '\n'
   else
     echo Aasdk Make failed with code $?
-    exit
+    exit 1
   fi
 
   #begin make install
@@ -199,7 +199,7 @@ else
     echo
   else
     echo Aasdk install failed with code $?
-    exit
+    exit 1
   fi
   cd ../../dash
 fi
@@ -225,8 +225,8 @@ if [ $gstreamer = true ]; then
         echo -e cloned OK '\n'
         cd ..
       else
-          echo Gstreamer clone/pull error
-        exit
+        echo Gstreamer clone/pull error
+        exit 1
       fi
   fi
 
@@ -253,7 +253,7 @@ if [ $gstreamer = true ]; then
     echo -e Make ok'\n'
   else
     echo Gstreamer CMake failed
-    exit
+    exit 1
   fi
 
   echo Making Gstreamer
@@ -263,7 +263,7 @@ if [ $gstreamer = true ]; then
     echo -e Gstreamer make ok'\n'
   else
     echo Make failed with error code $?
-    exit
+    exit 1
   fi
 
   #run make install
@@ -274,7 +274,7 @@ if [ $gstreamer = true ]; then
     echo -e Gstreamer installed ok'\n'
   else
     echo Gstreamer make install failed with error code $?
-    exit
+    exit 1
   fi
 
   sudo ldconfig
@@ -305,7 +305,7 @@ else
       cd ..
     else
       echo Openauto clone/pull error
-      exit
+      exit 1
     fi
   fi
 
@@ -314,7 +314,7 @@ else
   #create build directory
   echo Creating openauto build directory
   mkdir build
-  
+
   if [[ $? -eq 0 ]]; then
     echo -e openauto build directory made
   else
@@ -329,7 +329,7 @@ else
     echo -e Openauto CMake OK'\n'
   else
     echo Openauto CMake failed with error code $?
-    exit
+    exit 1
   fi
 
   echo Beginning openauto make
@@ -338,7 +338,7 @@ else
     echo -e Openauto make OK'\n'
   else
     echo Openauto make failed with error code $?
-    exit
+    exit 1
   fi
 
   #run make install
@@ -348,7 +348,7 @@ else
     echo -e Openauto installed ok'\n'
   else
     echo Openauto make install failed with error code $?
-    exit
+    exit 1
   fi
   cd ../../dash
 fi
@@ -378,7 +378,7 @@ else
     echo -e Dash CMake OK'\n'
   else
     echo Dash CMake failed with error code $?
-    exit
+    exit 1
   fi
 
   echo Running Dash make
@@ -404,7 +404,7 @@ else
       fi
     else
       echo Dash make failed with error code $?
-      exit
+      exit 1
   fi
 
   #Setting openGL driver and GPU memory to 256mb
@@ -414,7 +414,7 @@ else
       echo -e Memory set to 256mb'\n'
     else
       echo Setting memory failed with error code $? please set manually
-      exit
+      exit 1
     fi
 
     sudo raspi-config nonint do_gldriver G2
@@ -422,7 +422,7 @@ else
       echo -e OpenGL set ok'\n'
     else
       echo Setting openGL failed with error code $? please set manually
-      exit
+      exit 1
     fi
 
   fi

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,6 @@ display_help() {
     echo "   --gstreamer      install and build gstreamer "
     echo "   --dash           install and build dash "
     echo
-    exit 1
 }
 
 #location of OS details for linux


### PR DESCRIPTION
## Change Log
- Makes `install.sh` exit with error code on failure
- Fixes `install.sh --help` existing with error code

## Description
Previously the install script would always exit with exit code 0 even when failing to build, this causes problems if you want to use the script from inside of other scripts or in a one-liner such as `./install.sh && pkill dash`.

This PR makes the `install.sh` exit with exit code 1 if it failed to build.
