### PR TITLE
Add the ability to auto detect supported brightness plugins

### DIFF
--- a/include/app/config.hpp
+++ b/include/app/config.hpp
@@ -154,6 +154,12 @@ class Config : public QObject {
     inline void set_brightness_plugin(QString brightness_plugin)
     {
         this->brightness_plugin = brightness_plugin;
+
+        if (this->brightness_plugin == "auto") {
+            this->detect_brightness_plugin();
+            return;
+        }
+
         if (this->brightness_active_plugin->isLoaded())
             this->brightness_active_plugin->unload();
         this->brightness_active_plugin->setFileName(this->brightness_plugins[this->brightness_plugin].absoluteFilePath());
@@ -226,6 +232,7 @@ class Config : public QObject {
     QPluginLoader *brightness_active_plugin;
 
     void load_brightness_plugins();
+    void detect_brightness_plugin();
     void update_system_volume();
 
    signals:

--- a/include/app/config.hpp
+++ b/include/app/config.hpp
@@ -155,14 +155,19 @@ class Config : public QObject {
     {
         this->brightness_plugin = brightness_plugin;
 
-        if (this->brightness_plugin == "auto") {
-            this->detect_brightness_plugin();
-            return;
-        }
+        QString name = this->brightness_plugin;
 
-        if (this->brightness_active_plugin->isLoaded())
+        // If the brightness plugin is the special case "auto" we use the autodetected plugin
+        if (name == "auto")
+            name = this->autodetected_brightness_plugin;
+
+        QString fileName = this->brightness_plugins[name].absoluteFilePath();
+
+        // Only replace the active plugin if its differnt than the one we want
+        if (this->brightness_active_plugin->fileName() != fileName) {
             this->brightness_active_plugin->unload();
-        this->brightness_active_plugin->setFileName(this->brightness_plugins[this->brightness_plugin].absoluteFilePath());
+            this->brightness_active_plugin->setFileName(fileName);
+        }
     }
 
     inline bool get_vehicle_can_bus() { return this->vehicle_can_bus; }
@@ -213,6 +218,7 @@ class Config : public QObject {
     QMap<QString, QString> shortcuts;
     QString quick_view;
     QString brightness_plugin;
+    QString autodetected_brightness_plugin;
     bool controls_bar;
     double scale;
     QString cam_network_url;

--- a/include/plugins/brightness_plugin.hpp
+++ b/include/plugins/brightness_plugin.hpp
@@ -11,6 +11,8 @@ class BrightnessPlugin : public Plugin {
    public:
     BrightnessPlugin() { this->settings.beginGroup("Brightness"); }
     virtual ~BrightnessPlugin() = default;
+    virtual bool is_supported() = 0;
+    virtual uint8_t get_priority() = 0;
     virtual void set(int brightness) = 0;
 };
 

--- a/plugins/brightness/mocked/mocked.cpp
+++ b/plugins/brightness/mocked/mocked.cpp
@@ -12,6 +12,16 @@ Mocked::Mocked()
     }
 }
 
+bool Mocked::is_supported()
+{
+    return true;
+}
+
+uint8_t Mocked::get_priority()
+{
+    return 1;
+}
+
 void Mocked::set(int brightness)
 {
     if (this->window != nullptr)

--- a/plugins/brightness/mocked/mocked.hpp
+++ b/plugins/brightness/mocked/mocked.hpp
@@ -12,6 +12,8 @@ class Mocked : public QObject, BrightnessPlugin {
 
    public:
     Mocked();
+    bool is_supported() override;
+    uint8_t get_priority() override;
     void set(int brightness) override;
 
    private:

--- a/plugins/brightness/official_rpi/official_rpi.cpp
+++ b/plugins/brightness/official_rpi/official_rpi.cpp
@@ -18,7 +18,7 @@ bool OfficialRPi::is_supported()
 
 uint8_t OfficialRPi::get_priority()
 {
-    return 2;
+    return 3;
 }
 
 void OfficialRPi::set(int brightness)

--- a/plugins/brightness/official_rpi/official_rpi.cpp
+++ b/plugins/brightness/official_rpi/official_rpi.cpp
@@ -11,6 +11,16 @@ OfficialRPi::~OfficialRPi()
         this->brightness_attribute.close();
 }
 
+bool OfficialRPi::is_supported()
+{
+    return QFileInfo(this->brightness_attribute).isWritable();
+}
+
+uint8_t OfficialRPi::get_priority()
+{
+    return 2;
+}
+
 void OfficialRPi::set(int brightness)
 {
     if (this->brightness_attribute.isOpen()) {

--- a/plugins/brightness/official_rpi/official_rpi.hpp
+++ b/plugins/brightness/official_rpi/official_rpi.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QFile>
+#include <QFileInfo>
 #include <QObject>
 #include <QString>
 
@@ -14,6 +15,8 @@ class OfficialRPi : public QObject, BrightnessPlugin {
    public:
     OfficialRPi();
     ~OfficialRPi();
+    bool is_supported() override;
+    uint8_t get_priority() override;
     void set(int brightness) override;
 
    private:

--- a/plugins/brightness/x/x.cpp
+++ b/plugins/brightness/x/x.cpp
@@ -23,7 +23,7 @@ bool X::is_supported()
 
 uint8_t X::get_priority()
 {
-    return 1;
+    return 2;
 }
 
 void X::set(int brightness)

--- a/plugins/brightness/x/x.cpp
+++ b/plugins/brightness/x/x.cpp
@@ -9,6 +9,23 @@ X::X()
     this->screen = QGuiApplication::primaryScreen();
 }
 
+bool X::is_supported()
+{
+    if (this->screen != nullptr) {
+        // Check that we can execute xrandr
+        QProcess process(this);
+        process.start(QString("xrandr --version"));
+        process.waitForFinished();
+        return process.exitCode() == 0;
+    }
+    return false;
+}
+
+uint8_t X::get_priority()
+{
+    return 1;
+}
+
 void X::set(int brightness)
 {
     if (this->screen != nullptr) {

--- a/plugins/brightness/x/x.hpp
+++ b/plugins/brightness/x/x.hpp
@@ -10,6 +10,8 @@ class X : public QObject, BrightnessPlugin {
 
    public:
     X();
+    bool is_supported() override;
+    uint8_t get_priority() override;
     void set(int brightness) override;
 
    private:


### PR DESCRIPTION
## Description
**Related issue:** fixes https://github.com/openDsh/dash/issues/48

This PR adds the ability to automatically detect the supported brightness plugins.

When the config value for `brightness_plugin` is set to `auto`, which is the default, we iterate the available brightness plugins and check if they are supported and select the plugin that is the highest priority supported plugin.

**Implementations:**
- `official rpi` checks to see if `/sys/class/backlight/rpi_backlight/brightness` is writable and has the highest priority since it provides a true brightness control when available
- `mocked` is always supported 
- `x` is supported if `QGuiApplication::primaryScreen()` returned non-null and we can successfully execute `xrandr`

## Checklist:
  - [x] The code change is tested and works locally.
