### PR TITLE
Prevent Bluetooth from blocking dash startup

### DIFF
--- a/include/app/bluetooth.hpp
+++ b/include/app/bluetooth.hpp
@@ -46,6 +46,7 @@ class Bluetooth : public QObject {
     QTimer *scan_timer;
 
    signals:
+    void init();
     void device_added(BluezQt::DevicePtr);
     void device_changed(BluezQt::DevicePtr);
     void device_removed(BluezQt::DevicePtr);

--- a/src/app/bluetooth.cpp
+++ b/src/app/bluetooth.cpp
@@ -57,6 +57,8 @@ Bluetooth::Bluetooth() : QObject(qApp)
         }
 
         DASH_LOG(info) << "[Bluetooth] Has Adapter: " << this->has_adapter() << ", Has Media Device: " << (this->media_player_device != nullptr);
+
+        emit init();
     });
 }
 

--- a/src/app/bluetooth.cpp
+++ b/src/app/bluetooth.cpp
@@ -15,38 +15,49 @@
 #include <QBluetoothServiceInfo>
 #include <QTimer>
 
+#include "DashLog.hpp"
 #include "app/bluetooth.hpp"
 #include "app/widgets/progress.hpp"
 
 Bluetooth::Bluetooth() : QObject(qApp)
 {
-    BluezQt::Manager *manager = new BluezQt::Manager();
-    BluezQt::InitManagerJob *job = manager->init();
-    job->exec();
+    DASH_LOG(info) << "[Bluetooth] Init";
 
-    this->adapter = manager->usableAdapter();
-
+    // Setup the scan timeout
     this->scan_timer = new QTimer(this);
     this->scan_timer->setSingleShot(true);
     connect(this->scan_timer, &QTimer::timeout, [this]() { this->stop_scan(); });
 
-    if (this->has_adapter()) {
-        for (auto device : this->get_devices()) {
-            if (device->mediaPlayer() != nullptr) {
-                this->media_player_device = device;
-                break;
+    BluezQt::Manager *manager = new BluezQt::Manager();
+    BluezQt::InitManagerJob *job = manager->init();
+
+    // Run the job with start() so we don't block this thread
+    job->start();
+    connect(job, &BluezQt::InitManagerJob::result, [this, manager]() {
+        DASH_LOG(info) << "[Bluetooth] Init complete!";
+
+        this->adapter = manager->usableAdapter();
+
+        if (this->has_adapter()) {
+            for (auto device : this->get_devices()) {
+                if (device->mediaPlayer() != nullptr) {
+                    this->media_player_device = device;
+                    break;
+                }
             }
+
+            connect(this->adapter.data(), &BluezQt::Adapter::deviceAdded,
+                    [this](BluezQt::DevicePtr device) { emit device_added(device); });
+            connect(this->adapter.data(), &BluezQt::Adapter::deviceChanged, [this](BluezQt::DevicePtr device) {
+                emit device_changed(device);
+                this->update_media_player(device);
+            });
+            connect(this->adapter.data(), &BluezQt::Adapter::deviceRemoved,
+                    [this](BluezQt::DevicePtr device) { emit device_removed(device); });
         }
 
-        connect(this->adapter.data(), &BluezQt::Adapter::deviceAdded,
-                [this](BluezQt::DevicePtr device) { emit device_added(device); });
-        connect(this->adapter.data(), &BluezQt::Adapter::deviceChanged, [this](BluezQt::DevicePtr device) {
-            emit device_changed(device);
-            this->update_media_player(device);
-        });
-        connect(this->adapter.data(), &BluezQt::Adapter::deviceRemoved,
-                [this](BluezQt::DevicePtr device) { emit device_removed(device); });
-    }
+        DASH_LOG(info) << "[Bluetooth] Has Adapter: " << this->has_adapter() << ", Has Media Device: " << (this->media_player_device != nullptr);
+    });
 }
 
 void Bluetooth::start_scan()

--- a/src/app/pages/settings.cpp
+++ b/src/app/pages/settings.cpp
@@ -506,7 +506,10 @@ QWidget *BluetoothSettingsTab::scanner_widget()
     QPushButton *button = new QPushButton("scan", widget);
     button->setFlat(true);
     button->setCheckable(true);
-    button->setEnabled(this->bluetooth->has_adapter()); // this could potentially be tricky
+    button->setEnabled(false);
+    connect(this->bluetooth, &Bluetooth::init, [bluetooth = this->bluetooth, button]() {
+        button->setEnabled(bluetooth->has_adapter());
+    });
     button->setIconSize(Theme::icon_36);
     button->setIcon(this->theme->make_button_icon("bluetooth_searching", button));
     connect(button, &QPushButton::clicked, [bluetooth = this->bluetooth](bool checked) {


### PR DESCRIPTION
## Description:
The previous code used `job->exec()` which executes the init task in the [current thread](https://code.woboq.org/qt5/kf5/bluez-qt/src/job.h.html#94), this caused dash to block during start up.

I took a look at the documentation for [`BluezQt::Manager`](https://api.kde.org/frameworks/bluez-qt/html/classBluezQt_1_1Manager.html) and noticed it shows an example using `job->start()` and connecting to `BluezQt::InitManagerJob::result` so I modified the code to do just that.

Also added some log lines so its easy to see when this happens, how long it takes and if it found any devices.

## Checklist:
  - [x] The code change is tested and works locally.
