### PR TITLE
Vehicle/openauto settings update

### DIFF
--- a/include/app/pages/openauto.hpp
+++ b/include/app/pages/openauto.hpp
@@ -104,6 +104,7 @@ class OpenAutoPage : public QStackedWidget {
         QLayout *rt_audio_row_widget();
         QLayout *audio_channels_row_widget();
         QLayout *bluetooth_row_widget();
+        QLayout *autoconnect_row_widget();
         QLayout *touchscreen_row_widget();
         QCheckBox *button_checkbox(QString name, QString key, aasdk::proto::enums::ButtonCode::Enum code);
         QLayout *buttons_row_widget();

--- a/src/app/pages/openauto.cpp
+++ b/src/app/pages/openauto.cpp
@@ -95,6 +95,7 @@ QLayout *OpenAutoPage::Settings::settings_widget()
     layout->addLayout(this->audio_channels_row_widget(), 1);
     layout->addWidget(Theme::br(), 1);
     layout->addLayout(this->bluetooth_row_widget(), 1);
+    layout->addLayout(this->autoconnect_row_widget(), 1);
     layout->addWidget(Theme::br(), 1);
     layout->addLayout(this->touchscreen_row_widget(), 1);
     layout->addLayout(this->buttons_row_widget(), 1);
@@ -291,6 +292,25 @@ QLayout *OpenAutoPage::Settings::bluetooth_row_widget()
     connect(toggle, &Switch::stateChanged, [config = this->config](bool state) {
         config->openauto_config->setBluetoothAdapterType(state ? openauto::configuration::BluetoothAdapterType::LOCAL
                                                                : openauto::configuration::BluetoothAdapterType::NONE);
+    });
+    layout->addWidget(toggle, 1, Qt::AlignHCenter);
+
+    return layout;
+}
+
+QLayout *OpenAutoPage::Settings::autoconnect_row_widget()
+{
+    QHBoxLayout *layout = new QHBoxLayout();
+
+    QLabel *label = new QLabel("Autoconnect Last Device");
+    layout->addWidget(label, 1);
+
+    Switch *toggle = new Switch();
+    toggle->scale(this->config->get_scale());
+    toggle->setChecked(this->config->openauto_config->getAutoconnectBluetooth());
+    connect(this->config, &Config::scale_changed, [toggle](double scale) { toggle->scale(scale); });
+    connect(toggle, &Switch::stateChanged, [config = this->config](bool state) {
+        config->openauto_config->setAutoconnectBluetooth(state);
     });
     layout->addWidget(toggle, 1, Qt::AlignHCenter);
 

--- a/src/app/pages/vehicle.cpp
+++ b/src/app/pages/vehicle.cpp
@@ -102,8 +102,8 @@ VehiclePage::VehiclePage(QWidget *parent) : QTabWidget(parent)
     for (auto port : QSerialPortInfo::availablePorts())
         this->serial_devices.append(port.systemLocation());
 
-    this->can_devices.append("unloader");
-    this->serial_devices.append("unloader");
+    this->can_devices.append("No Interface");
+    this->serial_devices.append("No Interface");
 
     this->get_plugins();
     this->active_plugin = new QPluginLoader(this);
@@ -156,7 +156,6 @@ QWidget *VehiclePage::can_bus_toggle_row()
     connect(socketcan_button, &QRadioButton::clicked,
             [config = this->config]() { 
                 config->set_vehicle_can_bus(true); 
-                emit config->vehicle_can_bus_changed(true);
             });
     group_layout->addWidget(socketcan_button);
 
@@ -165,7 +164,6 @@ QWidget *VehiclePage::can_bus_toggle_row()
     connect(elm_button, &QRadioButton::clicked,
             [config = this->config]() { 
                 config->set_vehicle_can_bus(false); 
-                emit config->vehicle_can_bus_changed(false);
             });
     group_layout->addWidget(elm_button);
 


### PR DESCRIPTION
## Description:
Adds openauto autoconnect setting to the openauto page settings.
Adds unloader options for socketcan/elm327 devices to provide a way to deselect interfaces
Makes the interface selection between socketcan/elm327 clear

## Checklist:
  - [x] The code change is tested and works locally.

