### PR TITLE
[HOTFIX] Don't segfault on new bluetooth device

### DIFF
--- a/src/app/pages/settings.cpp
+++ b/src/app/pages/settings.cpp
@@ -19,6 +19,7 @@
 #include "app/widgets/switch.hpp"
 #include "app/window.hpp"
 #include "app/widgets/sliders.hpp"
+#include <QDebug>
 
 SettingsPage::SettingsPage(QWidget *parent) : QTabWidget(parent)
 {
@@ -575,8 +576,15 @@ QWidget *BluetoothSettingsTab::devices_widget()
         layout->addWidget(button);
     });
     connect(this->bluetooth, &Bluetooth::device_changed, [this](BluezQt::DevicePtr device) {
-        this->devices[device]->setText(device->name());
-        this->devices[device]->setChecked(device->isConnected());
+        if(!this->devices.contains(device))
+        {
+            emit this->bluetooth->device_added(device);
+        }
+        else
+        {
+            this->devices[device]->setText(device->name());
+            this->devices[device]->setChecked(device->isConnected());
+        }
     });
     connect(this->bluetooth, &Bluetooth::device_removed, [this, layout](BluezQt::DevicePtr device) {
         layout->removeWidget(devices[device]);


### PR DESCRIPTION
## Description:

device_added doesn't seem to always fire. This was causing segfaults on a new bluetooth connection.


## Checklist:
  - [x] The code change is tested and works locally.

