### PR TITLE
Fixed outdated qt-gstreamer link

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 #repo addresses
 aasdkRepo="https://github.com/OpenDsh/aasdk"
-gstreamerRepo="git://anongit.freedesktop.org/gstreamer/qt-gstreamer"
+gstreamerRepo="git://github.com/GStreamer/qt-gstreamer"
 openautoRepo="https://github.com/openDsh/openauto"
 
 #Help text


### PR DESCRIPTION
## Description:
Path no longer valid: anongit.freedesktop.org/gstreamer/qt-gstreamer".
Corrected to official mirror.

**Related issue (if applicable):** fixes #<issue number goes here>


## Checklist:
  - [x] The code change is tested and works locally.

