### PR TITLE
Fix iterator deref without PTE check

### DIFF
--- a/src/app/widgets/selector.cpp
+++ b/src/app/widgets/selector.cpp
@@ -32,9 +32,13 @@ QSize Selector::sizeHint() const
     auto it = std::max_element(this->options.begin(), this->options.end(), [](const auto &a, const auto &b){
         return a.size() < b.size();
     });
-
+    
+    int longestOptionSize = 1;
+    if(it != this->options.end())
+        longestOptionSize = it->size();
+    
     int base = 32 * this->arbiter.layout().scale;
-    int width = (base * 2) + std::max(this->label->width(), QFontMetrics(this->label->font()).width(it->size())) + (12 * 4);
+    int width = (base * 2) + std::max(this->label->width(), QFontMetrics(this->label->font()).width(longestOptionSize)) + (12 * 4);
     int height = std::max(base, this->label->height()) + (12 * 2);
     return QSize(width, height);
 }


### PR DESCRIPTION
## Description:
If dash is launched without plugins installed, a Selector instance is constructed for the settings UI (brightness plugin selector) with an empty options list. This results in a past-the-end iterator being returned from the max_element algorithm. This iterator should be checked before dereferencing, or the access results in a segmentation fault. This change provides a default length in that case.

An additional improvement would provide a warning message when the plugins cannot be found.

I'm picking up where @matt2005 left off on the Yocto build, and the main CMakeLists.txt has some problems that render it incompatible for cross compilation with Yocto. It seems that the plugins directory is not included properly somehow. More on that soon.

## Checklist:
  - [x] The code change is tested and works locally. (compile only, since this is a small edge case)

