### PR TITLE
Allows for injecting button presses into openauto

### DIFF
--- a/include/app/arbiter.hpp
+++ b/include/app/arbiter.hpp
@@ -10,7 +10,7 @@
 #include "app/session.hpp"
 #include "app/pages/page.hpp"
 #include "app/quick_views/quick_view.hpp"
-
+#include "openauto/Service/InputService.hpp"
 
 class Arbiter : public QObject {
     Q_OBJECT
@@ -45,6 +45,8 @@ class Arbiter : public QObject {
     Session::Forge &forge() { return this->session_.forge_; }
     Session::Core &core() { return this->session_.core_; }
     void update() { this->session_.update(); }
+
+    std::shared_ptr<openauto::service::InputService> inputService;
 
    private:
     QMainWindow *window_;

--- a/include/app/arbiter.hpp
+++ b/include/app/arbiter.hpp
@@ -12,6 +12,7 @@
 #include "app/quick_views/quick_view.hpp"
 #include "openauto/Service/InputService.hpp"
 
+
 class Arbiter : public QObject {
     Q_OBJECT
 
@@ -36,6 +37,7 @@ class Arbiter : public QObject {
     void increase_volume(uint8_t val);
     void set_cursor(bool enabled);
     void set_action(Action *action, QString key);
+    void send_openauto_button_press(aasdk::proto::enums::ButtonCode::Enum buttonCode);
 
     QMainWindow *window() { return this->window_; }
     QSettings &settings() { return this->session_.settings_; }
@@ -45,8 +47,6 @@ class Arbiter : public QObject {
     Session::Forge &forge() { return this->session_.forge_; }
     Session::Core &core() { return this->session_.core_; }
     void update() { this->session_.update(); }
-
-    std::shared_ptr<openauto::service::InputService> inputService;
 
    private:
     QMainWindow *window_;
@@ -65,4 +65,5 @@ class Arbiter : public QObject {
     void volume_changed(uint8_t volume);
     void cursor_changed(bool enabled);
     void action_changed(Action *action, QString key);
+    void openauto_button_press(aasdk::proto::enums::ButtonCode::Enum buttonCode);
 };

--- a/include/app/pages/openauto.hpp
+++ b/include/app/pages/openauto.hpp
@@ -27,7 +27,7 @@ class OpenAutoWorker : public QObject {
     Q_OBJECT
 
    public:
-    OpenAutoWorker(std::function<void(bool)> callback, bool night_mode, QWidget *frame);
+    OpenAutoWorker(std::function<void(bool)> callback, std::function<void(bool)> inputServiceCallback, bool night_mode, QWidget *frame);
     ~OpenAutoWorker();
 
     inline void start() { this->app->waitForDevice(true); }
@@ -35,6 +35,7 @@ class OpenAutoWorker : public QObject {
     inline void update_size() { this->service_factory.resize(); }
     inline void set_night_mode(bool mode) { this->service_factory.setNightMode(mode); }
     inline void send_key_event(QKeyEvent *event) { this->service_factory.sendKeyEvent(event); }
+    openauto::service::IService::Pointer getInputService();
 
    private:
     void create_usb_workers();

--- a/include/app/pages/openauto.hpp
+++ b/include/app/pages/openauto.hpp
@@ -21,13 +21,15 @@
 
 #include "app/pages/page.hpp"
 
+#include "DashLog.hpp"
+
 class Arbiter;
 
 class OpenAutoWorker : public QObject {
     Q_OBJECT
 
    public:
-    OpenAutoWorker(std::function<void(bool)> callback, std::function<void(bool)> inputServiceCallback, bool night_mode, QWidget *frame);
+    OpenAutoWorker(std::function<void(bool)> callback, bool night_mode, QWidget *frame);
     ~OpenAutoWorker();
 
     inline void start() { this->app->waitForDevice(true); }
@@ -35,7 +37,8 @@ class OpenAutoWorker : public QObject {
     inline void update_size() { this->service_factory.resize(); }
     inline void set_night_mode(bool mode) { this->service_factory.setNightMode(mode); }
     inline void send_key_event(QKeyEvent *event) { this->service_factory.sendKeyEvent(event); }
-    openauto::service::IService::Pointer getInputService();
+    inline void send_button_press(aasdk::proto::enums::ButtonCode::Enum buttonCode) { this->service_factory.sendButtonPress(buttonCode); };
+
 
    private:
     void create_usb_workers();

--- a/include/app/pages/openauto.hpp
+++ b/include/app/pages/openauto.hpp
@@ -39,7 +39,6 @@ class OpenAutoWorker : public QObject {
     inline void send_key_event(QKeyEvent *event) { this->service_factory.sendKeyEvent(event); }
     inline void send_button_press(aasdk::proto::enums::ButtonCode::Enum buttonCode) { this->service_factory.sendButtonPress(buttonCode); };
 
-
    private:
     void create_usb_workers();
     void create_io_service_workers();

--- a/src/app/arbiter.cpp
+++ b/src/app/arbiter.cpp
@@ -1,6 +1,7 @@
 #include "app/session.hpp"
-#include <QDebug>
+
 #include "app/arbiter.hpp"
+
 Arbiter::Arbiter(QMainWindow *window)
     : QObject()
     , window_(window)
@@ -15,7 +16,6 @@ void Arbiter::set_mode(Session::Theme::Mode mode)
 
     this->session_.update();
 
-    qDebug()<<"Mode change";
     emit mode_changed(mode);
     emit color_changed(this->theme().color());
 }

--- a/src/app/arbiter.cpp
+++ b/src/app/arbiter.cpp
@@ -1,7 +1,6 @@
 #include "app/session.hpp"
-
+#include <QDebug>
 #include "app/arbiter.hpp"
-
 Arbiter::Arbiter(QMainWindow *window)
     : QObject()
     , window_(window)
@@ -16,6 +15,7 @@ void Arbiter::set_mode(Session::Theme::Mode mode)
 
     this->session_.update();
 
+    qDebug()<<"Mode change";
     emit mode_changed(mode);
     emit color_changed(this->theme().color());
 }

--- a/src/app/arbiter.cpp
+++ b/src/app/arbiter.cpp
@@ -186,3 +186,8 @@ void Arbiter::set_action(Action *action, QString key)
 
     emit action_changed(action, key);
 }
+
+void Arbiter::send_openauto_button_press(aasdk::proto::enums::ButtonCode::Enum buttonCode)
+{
+    emit openauto_button_press(buttonCode);
+}

--- a/src/app/pages/openauto.cpp
+++ b/src/app/pages/openauto.cpp
@@ -4,7 +4,7 @@
 #include "app/widgets/progress.hpp"
 #include "app/window.hpp"
 
-OpenAutoWorker::OpenAutoWorker(std::function<void(bool)> callback, std::function<void(bool)> androidAutoStatusCallback, bool night_mode, QWidget *frame)
+OpenAutoWorker::OpenAutoWorker(std::function<void(bool)> callback, bool night_mode, QWidget *frame)
     : QObject(qApp),
       io_service(),
       work(io_service),
@@ -19,7 +19,7 @@ OpenAutoWorker::OpenAutoWorker(std::function<void(bool)> callback, std::function
       connected_accessories_enumerator(
           std::make_shared<aasdk::usb::ConnectedAccessoriesEnumerator>(usb_wrapper, io_service, query_chain_factory)),
       app(std::make_shared<openauto::App>(io_service, usb_wrapper, tcp_wrapper, android_auto_entity_factory, usb_hub,
-                                          connected_accessories_enumerator, androidAutoStatusCallback))
+                                          connected_accessories_enumerator))
 {
     this->create_usb_workers();
     this->create_io_service_workers();
@@ -56,11 +56,6 @@ void OpenAutoWorker::create_io_service_workers()
     this->thread_pool.emplace_back(worker);
     this->thread_pool.emplace_back(worker);
     this->thread_pool.emplace_back(worker);
-}
-
-openauto::service::IService::Pointer OpenAutoWorker::getInputService()
-{
-    return this->app->getInputService();
 }
 
 void OpenAutoFrame::mouseDoubleClickEvent(QMouseEvent *)
@@ -400,8 +395,7 @@ void OpenAutoPage::init()
     this->frame = new OpenAutoFrame(this);
 
     std::function<void(bool)> callback = [frame = this->frame](bool active) { frame->toggle(active); };
-    std::function<void(bool)> androidAutoStatusCallback = [this](bool created) { if(created) this->arbiter.inputService = std::dynamic_pointer_cast<openauto::service::InputService>(this->worker->getInputService());};
-    this->worker = new OpenAutoWorker(callback, androidAutoStatusCallback, this->arbiter.theme().mode == Session::Theme::Dark, frame);
+    this->worker = new OpenAutoWorker(callback, this->arbiter.theme().mode == Session::Theme::Dark, frame);
 
     connect(this->frame, &OpenAutoFrame::toggle, [this](bool enable) {
         if (!enable && this->frame->is_fullscreen()) {
@@ -422,6 +416,11 @@ void OpenAutoPage::init()
     });
     connect(&this->arbiter, &Arbiter::mode_changed, [this](Session::Theme::Mode mode){
         this->worker->set_night_mode(mode == Session::Theme::Dark);
+    });
+
+    connect(&this->arbiter, &Arbiter::openauto_button_press, [this](aasdk::proto::enums::ButtonCode::Enum buttonCode){
+        this->worker->send_button_press(buttonCode);
+        DASH_LOG(info)<<"[OpenAutoPage] Firing button press";
     });
 
     this->addWidget(this->connect_msg());


### PR DESCRIPTION
Adds method into arbiter that can inject button presses into OpenAuto (this means we can now play/pause/whatever from within dash and plugins).

Requires https://github.com/openDsh/openauto/pull/22