### PR TITLE
detect CPU cores count and utilize while building project

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,13 @@ display_help() {
 #location of OS details for linux
 OS_RELEASE_FILE="/etc/os-release"
 CPU_CORE_COUNT=`grep -c ^processor /proc/cpuinfo`
+RAM_SIZE=`free -g | grep "Mem:" | awk '{print $2}'`
+
+if [[ $(($RAM_SIZE + 0)) -lt 4 ]]; then
+  CPU_CORE_COUNT=2
+fi
+echo "RAM size is ${RAM_SIZE} GB, Utilizing threads: ${CPU_CORE_COUNT}"
+exit 0
 
 #check if Raspian is in the file, if not set the install Args to be false
 if grep -q "Raspbian" ${OS_RELEASE_FILE}; then

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,9 @@ RAM_SIZE=`free -g | grep "Mem:" | awk '{print $2}'`
 if [[ $(($RAM_SIZE + 0)) -lt 4 ]]; then
   CPU_CORE_COUNT=2
 fi
+if [[ $(($RAM_SIZE + 0)) -lt 2 ]]; then
+  CPU_CORE_COUNT=1
+fi
 echo "RAM size is ${RAM_SIZE} GB, Utilizing threads: ${CPU_CORE_COUNT}"
 
 #check if Raspian is in the file, if not set the install Args to be false

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ display_help() {
 
 #location of OS details for linux
 OS_RELEASE_FILE="/etc/os-release"
-CPU_CORES_COUNT=`grep -c ^processor /proc/cpuinfo`
+CPU_CORE_COUNT=`grep -c ^processor /proc/cpuinfo`
 
 #check if Raspian is in the file, if not set the install Args to be false
 if grep -q "Raspbian" ${OS_RELEASE_FILE}; then
@@ -186,7 +186,7 @@ else
   cd build
 
   #beginning cmake
-  cmake -DCMAKE_BUILD_TYPE=Release -- -j$CPU_CORES_COUNT ../
+  cmake -DCMAKE_BUILD_TYPE=Release -- -j$CPU_CORE_COUNT ../
   if [[ $? -eq 0 ]]; then
       echo -e Aasdk CMake completed successfully'\n'
   else
@@ -195,7 +195,7 @@ else
   fi
 
   #beginning make
-  make -j$CPU_CORES_COUNT
+  make -j$CPU_CORE_COUNT
 
   if [[ $? -eq 0 ]]; then
     echo -e Aasdk Make completed successfully '\n'
@@ -261,7 +261,7 @@ if [ $gstreamer = true ]; then
 
   #run cmake
   echo Beginning cmake
-  cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH) -DCMAKE_INSTALL_INCLUDEDIR=include -DQT_VERSION=5 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-std=c++11 -- -j$CPU_CORES_COUNT
+  cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH) -DCMAKE_INSTALL_INCLUDEDIR=include -DQT_VERSION=5 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-std=c++11 -- -j$CPU_CORE_COUNT
 
   if [[ $? -eq 0 ]]; then
     echo -e Make ok'\n'
@@ -271,7 +271,7 @@ if [ $gstreamer = true ]; then
   fi
 
   echo Making Gstreamer
-  make -j$CPU_CORES_COUNT
+  make -j$CPU_CORE_COUNT
 
   if [[ $? -eq 0 ]]; then
     echo -e Gstreamer make ok'\n'
@@ -338,7 +338,7 @@ else
   cd build
 
   echo Beginning openauto cmake
-  cmake ${installArgs} -DGST_BUILD=true -- -j$CPU_CORES_COUNT ../
+  cmake ${installArgs} -DGST_BUILD=true -- -j$CPU_CORE_COUNT ../
   if [[ $? -eq 0 ]]; then
     echo -e Openauto CMake OK'\n'
   else
@@ -347,7 +347,7 @@ else
   fi
 
   echo Beginning openauto make
-  make -j$CPU_CORES_COUNT
+  make -j$CPU_CORE_COUNT
   if [[ $? -eq 0 ]]; then
     echo -e Openauto make OK'\n'
   else
@@ -387,7 +387,7 @@ else
 
 	echo -e Installing dash'\n'
   echo Running CMake for dash
-  cmake ${installArgs} -DGST_BUILD=TRUE -- -j$CPU_CORES_COUNT ../
+  cmake ${installArgs} -DGST_BUILD=TRUE -- -j$CPU_CORE_COUNT ../
   if [[ $? -eq 0 ]]; then
     echo -e Dash CMake OK'\n'
   else
@@ -396,7 +396,7 @@ else
   fi
 
   echo Running Dash make
-  make -j$CPU_CORES_COUNT
+  make -j$CPU_CORE_COUNT
   if [[ $? -eq 0 ]]; then
       echo -e Dash make ok, executable can be found ../bin/dash
       echo

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,6 @@ if [[ $(($RAM_SIZE + 0)) -lt 4 ]]; then
   CPU_CORE_COUNT=2
 fi
 echo "RAM size is ${RAM_SIZE} GB, Utilizing threads: ${CPU_CORE_COUNT}"
-exit 0
 
 #check if Raspian is in the file, if not set the install Args to be false
 if grep -q "Raspbian" ${OS_RELEASE_FILE}; then

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,7 @@ display_help() {
 
 #location of OS details for linux
 OS_RELEASE_FILE="/etc/os-release"
+CPU_CORES_COUNT=`grep -c ^processor /proc/cpuinfo`
 
 #check if Raspian is in the file, if not set the install Args to be false
 if grep -q "Raspbian" ${OS_RELEASE_FILE}; then
@@ -185,7 +186,7 @@ else
   cd build
 
   #beginning cmake
-  cmake -DCMAKE_BUILD_TYPE=Release ../
+  cmake -DCMAKE_BUILD_TYPE=Release -- -j$CPU_CORES_COUNT ../
   if [[ $? -eq 0 ]]; then
       echo -e Aasdk CMake completed successfully'\n'
   else
@@ -194,7 +195,7 @@ else
   fi
 
   #beginning make
-  make -j2
+  make -j$CPU_CORES_COUNT
 
   if [[ $? -eq 0 ]]; then
     echo -e Aasdk Make completed successfully '\n'
@@ -260,7 +261,7 @@ if [ $gstreamer = true ]; then
 
   #run cmake
   echo Beginning cmake
-  cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH) -DCMAKE_INSTALL_INCLUDEDIR=include -DQT_VERSION=5 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-std=c++11
+  cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH) -DCMAKE_INSTALL_INCLUDEDIR=include -DQT_VERSION=5 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-std=c++11 -- -j$CPU_CORES_COUNT
 
   if [[ $? -eq 0 ]]; then
     echo -e Make ok'\n'
@@ -270,7 +271,7 @@ if [ $gstreamer = true ]; then
   fi
 
   echo Making Gstreamer
-  make -j4
+  make -j$CPU_CORES_COUNT
 
   if [[ $? -eq 0 ]]; then
     echo -e Gstreamer make ok'\n'
@@ -337,7 +338,7 @@ else
   cd build
 
   echo Beginning openauto cmake
-  cmake ${installArgs} -DGST_BUILD=true ../
+  cmake ${installArgs} -DGST_BUILD=true -- -j$CPU_CORES_COUNT ../
   if [[ $? -eq 0 ]]; then
     echo -e Openauto CMake OK'\n'
   else
@@ -346,7 +347,7 @@ else
   fi
 
   echo Beginning openauto make
-  make
+  make -j$CPU_CORES_COUNT
   if [[ $? -eq 0 ]]; then
     echo -e Openauto make OK'\n'
   else
@@ -386,7 +387,7 @@ else
 
 	echo -e Installing dash'\n'
   echo Running CMake for dash
-  cmake ${installArgs} -DGST_BUILD=TRUE ../
+  cmake ${installArgs} -DGST_BUILD=TRUE -- -j$CPU_CORES_COUNT ../
   if [[ $? -eq 0 ]]; then
     echo -e Dash CMake OK'\n'
   else
@@ -395,7 +396,7 @@ else
   fi
 
   echo Running Dash make
-  make
+  make -j$CPU_CORES_COUNT
   if [[ $? -eq 0 ]]; then
       echo -e Dash make ok, executable can be found ../bin/dash
       echo


### PR DESCRIPTION
## Description:

Improve build speed. Detect core count and set accordingly cmake and make command line params.

## Checklist:
  - [X ] The code change is tested and works locally.

