### PR TITLE
 fixes #81 ambiguous overload

### DIFF
--- a/src/canbus/elm327.cpp
+++ b/src/canbus/elm327.cpp
@@ -141,7 +141,7 @@ QCanBusFrame elm327::receive()
 
     retFrame->setFrameId(0x7E8);
     QByteArray payload = QByteArray::fromHex("0000000000000000");
-    for( std::vector<int>::size_type i=0; i < resp_str.length()/2; i++){
+    for( uint i=0; i < resp_str.length()/2; i++){
         payload[i+1] = std::stoi(resp_str.substr(2*i, 2), nullptr, 16);
     }
     payload[0] = resp_str.length()/2;


### PR DESCRIPTION
## Description:

fixes #81, building on Ubuntu 21.04, after last patch (#82), I get error  ambiguous overload.

## Checklist:
  - [X] The code change is tested and works locally.

```bash
[ 46%] Building CXX object CMakeFiles/dash.dir/src/canbus/elm327.cpp.o
/home/egidijusz@OLVINET.drinkgroup.local/src/dash/src/canbus/elm327.cpp: In member function ‘QCanBusFrame elm327::receive()’:
/home/egidijusz@OLVINET.drinkgroup.local/src/dash/src/canbus/elm327.cpp:145:16: error: ambiguous overload for ‘operator[]’ (operand types are ‘QByteArray’ and ‘std::vector<int>::size_type’ {aka ‘long unsigned int’})
  145 |         payload[i+1] = std::stoi(resp_str.substr(2*i, 2), nullptr, 16);
      |                ^
/home/egidijusz@OLVINET.drinkgroup.local/src/dash/src/canbus/elm327.cpp:145:16: note: candidate: ‘operator[](const char*, long int)’ (built-in)
In file included from /usr/include/x86_64-linux-gnu/qt5/QtCore/qmetatype.h:47,
                 from /usr/include/x86_64-linux-gnu/qt5/QtSerialBus/qcanbusframe.h:40,
                 from /usr/include/x86_64-linux-gnu/qt5/QtSerialBus/QCanBusFrame:1,
                 from /home/egidijusz@OLVINET.drinkgroup.local/src/dash/include/canbus/elm327.hpp:4,
                 from /home/egidijusz@OLVINET.drinkgroup.local/src/dash/src/canbus/elm327.cpp:1:
/usr/include/x86_64-linux-gnu/qt5/QtCore/qbytearray.h:501:13: note: candidate: ‘char QByteArray::operator[](int) const’
  501 | inline char QByteArray::operator[](int i) const
      |             ^~~~~~~~~~
/usr/include/x86_64-linux-gnu/qt5/QtCore/qbytearray.h:503:13: note: candidate: ‘char QByteArray::operator[](uint) const’
  503 | inline char QByteArray::operator[](uint i) const
      |             ^~~~~~~~~~
/usr/include/x86_64-linux-gnu/qt5/QtCore/qbytearray.h:626:17: note: candidate: ‘QByteRef QByteArray::operator[](int)’
  626 | inline QByteRef QByteArray::operator[](int i)
      |                 ^~~~~~~~~~
/usr/include/x86_64-linux-gnu/qt5/QtCore/qbytearray.h:628:17: note: candidate: ‘QByteRef QByteArray::operator[](uint)’
  628 | inline QByteRef QByteArray::operator[](uint i)
      |                 ^~~~~~~~~~
make[2]: *** [CMakeFiles/dash.dir/build.make:481: CMakeFiles/dash.dir/src/canbus/elm327.cpp.o] Error 1
```