### PR TITLE
fixes #95 dark theme icons

### DIFF
--- a/include/app/session.hpp
+++ b/include/app/session.hpp
@@ -140,8 +140,8 @@ class Session {
         static void symbolize(QAbstractButton *button);
 
         Forge(Arbiter &arbiter);
-        void iconize(QString name, QAbstractButton *button, uint8_t size, bool dynamic = false) const;
-        void iconize(QString name, QString alt_name, QAbstractButton *button, uint8_t size, bool dynamic = false) const;
+        void iconize(QString name, QAbstractButton *button, uint8_t size, bool dynamic = true) const;
+        void iconize(QString name, QString alt_name, QAbstractButton *button, uint8_t size, bool dynamic = true) const;
         void set_icon(QString name, QAbstractButton *button, bool dynamic) const;
         QFont font(int size, bool mono = false) const;
         QWidget *brightness_slider(bool buttons = true) const;

--- a/src/app/session.cpp
+++ b/src/app/session.cpp
@@ -317,7 +317,7 @@ void Session::Forge::iconize(QString name, QAbstractButton *button, uint8_t size
 void Session::Forge::set_icon(QString name, QAbstractButton *button, bool dynamic) const
 {
     button->setIcon(QIcon(QString(":/icons/%1.svg").arg(name)));
-    button->setProperty("colorized",false);
+    button->setProperty("colorized", true);
     if (dynamic)
         this->arbiter_.theme().colorize(button);
 }
@@ -499,9 +499,9 @@ void Session::update()
         qApp->setStyleSheet(this->core_.stylesheet(this->theme_.mode, this->layout_.scale));
 
         for (QWidget *widget : qApp->allWidgets()) {
-	  if( auto button = qobject_cast<QAbstractButton*>(widget) )
-            if (button->property("colorized").toBool())
-                this->theme_.colorize(button);
+            if (auto button = qobject_cast<QAbstractButton*>(widget))
+                if (button->property("colorized").toBool())
+                    this->theme_.colorize(button);
         }
     }
 }

--- a/src/app/session.cpp
+++ b/src/app/session.cpp
@@ -317,7 +317,7 @@ void Session::Forge::iconize(QString name, QAbstractButton *button, uint8_t size
 void Session::Forge::set_icon(QString name, QAbstractButton *button, bool dynamic) const
 {
     button->setIcon(QIcon(QString(":/icons/%1.svg").arg(name)));
-    button->setProperty("colorized", true);
+    button->setProperty("colorized", false);
     if (dynamic)
         this->arbiter_.theme().colorize(button);
 }


### PR DESCRIPTION
## Description:

fixes #95 

This condition blocks from coloring some buttons:
https://github.com/openDsh/dash/blob/b985a43a34a20dade264e323578a4d55a4ec7674/src/app/session.cpp#L503

But if commented out, then some unwanted UI icons show up in other buttons :(
So I found other place where this property is set and changed to true:
https://github.com/openDsh/dash/blob/b985a43a34a20dade264e323578a4d55a4ec7674/src/app/session.cpp#L320

## Checklist:
  - [X] The code change is tested and works locally.

## Result:
![dash-icons-fixed](https://user-images.githubusercontent.com/1941760/130111823-7407169a-cfcf-4853-85d9-3cb0911a2d5a.png)
