### PR TITLE
Fixed Dependency Issues on Ubuntu 20.04 Fixes #86

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -127,9 +127,9 @@ if [ $deps = false ]
     echo Running apt update
     sudo apt update
 
-    installString="sudo apt install -y "
+    installString="sudo apt-get install -y "
 
-    #create apt install string
+    #create apt-get install string
     for i in ${dependencies[@]}; do
       installString+=" $i"
     done


### PR DESCRIPTION
Fixes #86 
Changed install script apt install to apt-get install to fix dependency not found issues on Ubuntu 20.04

## Description:


**Related issue (if applicable):** fixes #86


## Checklist:
  - [ ] The code change is tested and works locally.
  Tested on lubuntu (Ubuntu lxde) 20.04.3 in a Virtualbox virtual machine

