### PR TITLE
[Hotfix] Reorder declaration of structs to prevent segfault

### DIFF
--- a/include/app/session.hpp
+++ b/include/app/session.hpp
@@ -186,6 +186,6 @@ class Session {
     Layout layout_;
     System system_;
     Forge forge_;
-    Core core_;
     AndroidAuto android_auto_;
+    Core core_;
 };


### PR DESCRIPTION
Initializer lists run in the order of declaration. With previous declaration order, Session::Core::Core was capturing uninitialized handler for all the Action lambdas, causing segfault on action usage.