### PR TITLE
Queue page change to avoid deadlock

### DIFF
--- a/src/app/session.cpp
+++ b/src/app/session.cpp
@@ -397,12 +397,24 @@ Session::Core::Core(QSettings &settings, Arbiter &arbiter)
     };
 
     for (auto page : arbiter.layout().pages()) {
-        auto callback = [&arbiter, page](Action::ActionState actionState){ if(actionState == Action::ActionState::Triggered || actionState == Action::ActionState::Activated) arbiter.set_curr_page(page); };
+        auto callback = [&arbiter, page](Action::ActionState actionState){ 
+            if(actionState == Action::ActionState::Triggered || actionState == Action::ActionState::Activated) {
+                QMetaObject::invokeMethod(&arbiter, [&arbiter, page](){
+                    arbiter.set_curr_page(page);
+                }, Qt::QueuedConnection);
+            }
+        };
         this->actions_.append(new Action(QString("Show %1 Page").arg(page->name()), callback, arbiter.window()));
     }
 
     {
-        auto callback = [&arbiter](Action::ActionState actionState){ if(actionState == Action::ActionState::Triggered || actionState == Action::ActionState::Activated) arbiter.set_curr_page(arbiter.layout().next_enabled_page(arbiter.layout().curr_page)); };
+        auto callback = [&arbiter](Action::ActionState actionState){ 
+            if(actionState == Action::ActionState::Triggered || actionState == Action::ActionState::Activated){
+                QMetaObject::invokeMethod(&arbiter, [&arbiter](){
+                    arbiter.set_curr_page(arbiter.layout().next_enabled_page(arbiter.layout().curr_page));
+                }, Qt::QueuedConnection);
+            }
+        };
         this->actions_.append(new Action("Cycle Page", callback, arbiter.window()));
     }
 


### PR DESCRIPTION
When I changed how actions are detected to allow discrete press/release events, this causes Actions to be fired from eventHandler.
Widget change tries to call eventHandler because there's a change event. This causes a deadlock on widget change.

To avoid, queue page change to arbiter's event loop instead of firing immediately.
There may be an argument to be made around queuing all Actions fired by eventHandler, but not sure.

Fixes #115 