### PR TITLE
Bluetooth ELM327 Support

### DIFF
--- a/InfinitiG37
+++ b/InfinitiG37
@@ -1,0 +1,1 @@
+/home/icecube45/Dash_InfinitiG37/InfinitiG37

--- a/InfinitiG37
+++ b/InfinitiG37
@@ -1,1 +1,0 @@
-/home/icecube45/Dash_InfinitiG37/InfinitiG37

--- a/include/app/config.hpp
+++ b/include/app/config.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "openauto/Configuration/Configuration.hpp"
+#include "canbus/ICANBus.hpp"
 
 #include <QObject>
 #include <QSettings>
@@ -63,8 +64,8 @@ class Config : public QObject {
         emit si_units_changed(this->si_units);
     }
 
-    inline int get_vehicle_can_bus() { return this->vehicle_can_bus; }
-    inline void set_vehicle_can_bus(int vehicle_can_bus)
+    inline ICANBus::VehicleBusType get_vehicle_can_bus() { return this->vehicle_can_bus; }
+    inline void set_vehicle_can_bus(ICANBus::VehicleBusType vehicle_can_bus)
     {
         this->vehicle_can_bus = vehicle_can_bus;
         this->settings.setValue("Pages/Vehicle/can_bus", this->vehicle_can_bus);
@@ -185,7 +186,7 @@ class Config : public QObject {
     QString radio_plugin;
     QString media_home;
     bool si_units;
-    int vehicle_can_bus;
+    ICANBus::VehicleBusType vehicle_can_bus;
     QString vehicle_interface;
     QString vehicle_plugin;
     QString cam_network_url;
@@ -204,6 +205,6 @@ class Config : public QObject {
     void si_units_changed(bool si_units);
     void cam_autoconnect_changed(bool enabled);
     void cam_overlay_changed(bool enabled);
-    void vehicle_can_bus_changed(int state);
+    void vehicle_can_bus_changed(ICANBus::VehicleBusType state);
     void vehicle_interface_changed(QString interface);
 };

--- a/include/app/config.hpp
+++ b/include/app/config.hpp
@@ -63,8 +63,8 @@ class Config : public QObject {
         emit si_units_changed(this->si_units);
     }
 
-    inline bool get_vehicle_can_bus() { return this->vehicle_can_bus; }
-    inline void set_vehicle_can_bus(bool vehicle_can_bus)
+    inline int get_vehicle_can_bus() { return this->vehicle_can_bus; }
+    inline void set_vehicle_can_bus(int vehicle_can_bus)
     {
         this->vehicle_can_bus = vehicle_can_bus;
         this->settings.setValue("Pages/Vehicle/can_bus", this->vehicle_can_bus);
@@ -185,7 +185,7 @@ class Config : public QObject {
     QString radio_plugin;
     QString media_home;
     bool si_units;
-    bool vehicle_can_bus;
+    int vehicle_can_bus;
     QString vehicle_interface;
     QString vehicle_plugin;
     QString cam_network_url;
@@ -204,6 +204,6 @@ class Config : public QObject {
     void si_units_changed(bool si_units);
     void cam_autoconnect_changed(bool enabled);
     void cam_overlay_changed(bool enabled);
-    void vehicle_can_bus_changed(bool state);
+    void vehicle_can_bus_changed(int state);
     void vehicle_interface_changed(QString interface);
 };

--- a/include/app/pages/vehicle.hpp
+++ b/include/app/pages/vehicle.hpp
@@ -3,6 +3,7 @@
 #include <QPair>
 #include <QtWidgets>
 #include <QPluginLoader>
+#include <QMap>
 
 #include "canbus/socketcanbus.hpp"
 #include "obd/message.hpp"
@@ -66,8 +67,7 @@ class VehiclePage : public QTabWidget, public Page {
     QMap<QString, QFileInfo> plugins;
     QStringList can_devices;
     QStringList serial_devices;
-    QStringList paired_bt_names;
-    QStringList paired_bt_addresses;
+    QMap<QString, QString> paired_bt_devices;
     QPluginLoader *active_plugin;
     Selector *plugin_selector;
     Config *config;

--- a/include/app/pages/vehicle.hpp
+++ b/include/app/pages/vehicle.hpp
@@ -66,6 +66,8 @@ class VehiclePage : public QTabWidget, public Page {
     QMap<QString, QFileInfo> plugins;
     QStringList can_devices;
     QStringList serial_devices;
+    QStringList paired_bt_names;
+    QStringList paired_bt_addresses;
     QPluginLoader *active_plugin;
     Selector *plugin_selector;
     Config *config;

--- a/include/app/widgets/selector.hpp
+++ b/include/app/widgets/selector.hpp
@@ -23,6 +23,7 @@ class Selector : public QWidget {
         emit item_changed(this->get_current());
         emit idx_changed(this->current_idx - (this->placeholder.isNull() ? 0 : 1));
     }
+    void set_current(QString current);
 
    protected:
     QSize sizeHint() const override;

--- a/include/canbus/ICANBus.hpp
+++ b/include/canbus/ICANBus.hpp
@@ -1,8 +1,13 @@
 #pragma once
 #include <QCanBus>
 #include <functional>
-class ICANBus {
+#include <QObject>
+
+class ICANBus : public QObject {
+   Q_OBJECT
    public:
       virtual bool writeFrame(QCanBusFrame frame) = 0;
       virtual void registerFrameHandler(int id, std::function<void(QByteArray)> callback) = 0;
+      enum VehicleBusType { SocketCAN, ELM327USB, ELM327BT };
+      Q_ENUM(VehicleBusType)
 };

--- a/include/canbus/ICANBus.hpp
+++ b/include/canbus/ICANBus.hpp
@@ -3,7 +3,6 @@
 #include <functional>
 class ICANBus {
    public:
-      static ICANBus *get_instance();
       virtual bool writeFrame(QCanBusFrame frame) = 0;
       virtual void registerFrameHandler(int id, std::function<void(QByteArray)> callback) = 0;
 };

--- a/include/canbus/elm327.hpp
+++ b/include/canbus/elm327.hpp
@@ -7,6 +7,7 @@
 #include <QVector>
 #include <QByteArray>
 #include <QVariant>
+#include <QTimer>
 #include <termios.h>
 #include <fcntl.h>
 #include <unistd.h>

--- a/include/canbus/elm327.hpp
+++ b/include/canbus/elm327.hpp
@@ -23,7 +23,7 @@
 #include "canbus/ICANBus.hpp"
 #include "app/config.hpp"
 
-class elm327 : public QObject, public ICANBus
+class elm327 : public ICANBus
 {
     Q_OBJECT
     public:

--- a/include/canbus/elm327.hpp
+++ b/include/canbus/elm327.hpp
@@ -46,6 +46,7 @@ class elm327 : public ICANBus
         int fd;
         std::mutex elm_mutex;
         std::map<int, std::vector<std::function<void(QByteArray)>>> callbacks;
+        QTimer* bluetooth_watchdog;
 
         void connect(std::string dev_path, speed_t baudrate);
         void handleFrame(QCanBusFrame frame);

--- a/include/canbus/socketcanbus.hpp
+++ b/include/canbus/socketcanbus.hpp
@@ -9,7 +9,7 @@
 #include "canbus/ICANBus.hpp"
 #include "app/config.hpp"
 
-class SocketCANBus : public QObject, public ICANBus
+class SocketCANBus : public ICANBus
 {
     Q_OBJECT
     public:

--- a/src/app/config.cpp
+++ b/src/app/config.cpp
@@ -17,7 +17,7 @@ Config::Config()
     // 0 - SocketCAN
     // 1 - Elm 327 USB
     // 2 - Elm 327 Bluetooth
-    this->vehicle_can_bus = this->settings.value("Pages/Vehicle/can_bus", 0).toInt();
+    this->vehicle_can_bus = (ICANBus::VehicleBusType)(this->settings.value("Pages/Vehicle/can_bus", ICANBus::VehicleBusType::SocketCAN).toInt());
     this->vehicle_interface = this->settings.value("Pages/Vehicle/interface", "disabled").toString();
     this->vehicle_plugin = this->settings.value("Pages/Vehicle/plugin", "unloader").toString();
     this->cam_network_url = this->settings.value("Pages/Camera/stream_url", QString()).toString();

--- a/src/app/config.cpp
+++ b/src/app/config.cpp
@@ -14,7 +14,10 @@ Config::Config()
     this->radio_plugin = this->settings.value("Pages/Media/Radio/plugin", "unloader").toString();
     this->media_home = this->settings.value("Pages/Media/Local/home", QDir().absolutePath()).toString();
     this->si_units = this->settings.value("Pages/Vehicle/si_units", false).toBool();
-    this->vehicle_can_bus = this->settings.value("Pages/Vehicle/can_bus", false).toBool();
+    // 0 - SocketCAN
+    // 1 - Elm 327 USB
+    // 2 - Elm 327 Bluetooth
+    this->vehicle_can_bus = this->settings.value("Pages/Vehicle/can_bus", 0).toInt();
     this->vehicle_interface = this->settings.value("Pages/Vehicle/interface", "disabled").toString();
     this->vehicle_plugin = this->settings.value("Pages/Vehicle/plugin", "unloader").toString();
     this->cam_network_url = this->settings.value("Pages/Camera/stream_url", QString()).toString();

--- a/src/app/pages/vehicle.cpp
+++ b/src/app/pages/vehicle.cpp
@@ -180,14 +180,14 @@ QWidget *VehiclePage::dialog_body()
    
     Selector *interface_selector = new Selector(devices, this->config->get_vehicle_interface(), this->arbiter.forge().font(14), this->arbiter, widget, "disabled");
     interface_selector->setVisible((this->can_devices.size() > 0) || (this->serial_devices.size() > 0) || (this->paired_bt_devices.size() > 0));
-    connect(interface_selector, &Selector::item_changed, [config = this->config, this](QString item){
-        if(config->get_vehicle_can_bus()==ICANBus::VehicleBusType::ELM327BT && item != QString("disabled"))
+    connect(interface_selector, &Selector::item_changed, [this](QString item){
+        if(this->config->get_vehicle_can_bus()==ICANBus::VehicleBusType::ELM327BT && item != QString("disabled"))
         {
-            config->set_vehicle_interface(this->paired_bt_devices[item]);
+            this->config->set_vehicle_interface(this->paired_bt_devices[item]);
         }
         else
         {
-            config->set_vehicle_interface(item);
+            this->config->set_vehicle_interface(item);
         }
     });
     connect(this->config, &Config::vehicle_can_bus_changed, [this, interface_selector](int state){

--- a/src/app/pages/vehicle.cpp
+++ b/src/app/pages/vehicle.cpp
@@ -210,7 +210,13 @@ QWidget *VehiclePage::dialog_body()
     });
     connect(&this->arbiter.system().bluetooth, &Bluetooth::init, [this, interface_selector]{
         interface_selector->setVisible((this->can_devices.size() > 0) || (this->serial_devices.size() > 0) || (this->paired_bt_names.size() > 0));
-        if(this->config->get_vehicle_can_bus()==2) interface_selector->set_options(this->paired_bt_names);
+        if(this->config->get_vehicle_can_bus()==2){
+            QString current = this->config->get_vehicle_interface();
+            interface_selector->set_options(this->paired_bt_names);
+            if(current != "disabled")
+                interface_selector->set_current(this->paired_bt_names[this->paired_bt_addresses.indexOf(current)]);
+
+        }
     });
     layout->addWidget(interface_selector, 1);
 

--- a/src/app/widgets/selector.cpp
+++ b/src/app/widgets/selector.cpp
@@ -5,7 +5,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QList>
-
+#include "DashLog.hpp"
 #include "app/arbiter.hpp"
 #include "app/widgets/selector.hpp"
 
@@ -25,6 +25,14 @@ Selector::Selector(QList<QString> options, QString current, QFont font, Arbiter 
     QVBoxLayout *layout = new QVBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->addLayout(this->selector());
+}
+
+void Selector::set_current(QString current)
+{
+    this->current_idx = std::max(0, this->options.indexOf(current));
+    this->update_label();
+    emit item_changed(this->get_current());
+    emit idx_changed(this->current_idx);
 }
 
 QSize Selector::sizeHint() const

--- a/src/canbus/elm327.cpp
+++ b/src/canbus/elm327.cpp
@@ -211,8 +211,10 @@ std::string elm327::_read()
 {
     char buf[1];
     std::string str;
+    int failure_count = 0;
 
     while (true) {
+
         if (((adapterType==BT)?(::recv(btSocket->socketDescriptor(), (void *) buf, 1, 0)):(read(this->fd, (void *)buf, 1))) != 1)
         {
             if(adapterType != BT)
@@ -223,8 +225,13 @@ std::string elm327::_read()
             }
             else
             {
+                if(failure_count++ > 15)
+                {
+                    DASH_LOG(error) << "[ELM327] Bluetooth device failed read 15 times in a row, disconnecting";
+                    this->connected = false;
+                    return "";
+                }
                 continue;
-                //return "";
             }
         }
         if (buf[0] == '>')

--- a/src/canbus/elm327.cpp
+++ b/src/canbus/elm327.cpp
@@ -1,10 +1,18 @@
 #include "canbus/elm327.hpp"
 
-elm327::elm327(QString canInterface)
+elm327::elm327(QString canInterface, bool bluetooth)
 {
-    DASH_LOG(info)<<"[ELM327] Connecting elm "<<canInterface.toStdString();
-    this->connect(canInterface, B115200);
-    if (this->connected) this->initialize();
+    DASH_LOG(info)<<"[ElM327] Attempting to connect to elm device: "<<canInterface.toStdString();
+    if(bluetooth){
+        btSocket = new QBluetoothSocket(QBluetoothServiceInfo::RfcommProtocol);
+        QObject::connect(btSocket, &QBluetoothSocket::connected, this, &elm327::btConnected);
+        QObject::connect(btSocket, &QBluetoothSocket::stateChanged, this, &elm327::socketChanged);
+        btSocket->connectToService(QBluetoothAddress(canInterface), QBluetoothUuid(QString("00001101-0000-1000-8000-00805F9B34FB")), QIODevice::ReadWrite);
+    }
+    else{
+        this->connect(canInterface, B115200);
+        if (this->connected) this->initialize();
+    }
 
 }
 elm327::~elm327()
@@ -15,17 +23,50 @@ elm327::~elm327()
     this->connected = false;
 }
 
-elm327 *elm327::get_instance()
+elm327 *elm327::get_usb_instance()
 {
-    static elm327 elm(Config::get_instance()->get_vehicle_interface());
-    return &elm;
+    static elm327 elm_usb(Config::get_instance()->get_vehicle_interface());
+    return &elm_usb;
+}
+
+elm327 *elm327::get_bt_instance()
+{
+    static elm327 elm_bt(Config::get_instance()->get_vehicle_interface(), true);
+    return &elm_bt;
+}
+
+void elm327::btConnected()
+{
+    this->adapterType = BT; 
+    this->connected=true;
+    this->initialize();
+}
+
+void elm327::socketChanged(QBluetoothSocket::SocketState state)
+{
+    switch(state){
+        case(QBluetoothSocket::UnconnectedState):
+            DASH_LOG(info)<<"[ElM327][Bluetooth] Unconnected";
+            break;
+        case(QBluetoothSocket::ConnectingState):
+            DASH_LOG(info)<<"[ElM327][Bluetooth] Connecting";
+            break;
+        case(QBluetoothSocket::ConnectedState):
+            DASH_LOG(info)<<"[ElM327][Bluetooth] Connected";
+            break;
+        case(QBluetoothSocket::ServiceLookupState):
+            DASH_LOG(info)<<"[ElM327][Bluetooth] Looking up Services";
+            break;
+        default:
+            DASH_LOG(info)<<"[ElM327][Bluetooth] Unimplemented";
+    }
 }
 
 int elm327::_write(std::string str)
 {
     str += '\r';
     int size;
-    if ((size = write(this->fd, str.c_str(), str.length())) < 0) {
+    if ((size = (adapterType==BT)?(::send(btSocket->socketDescriptor(), str.c_str(), str.length(),0)):(write(this->fd, str.c_str(), str.length()))) < 0) {
         DASH_LOG(error) << "[ELM327] failed write" << std::endl;
         this->connected = false;
         return 0;
@@ -172,10 +213,17 @@ std::string elm327::_read()
     std::string str;
 
     while (true) {
-        if (read(this->fd, (void *)buf, 1) != 1) {
+        if ((adapterType==BT)?(::recv(btSocket->socketDescriptor(), (void *) buf, 1, 0)):(read(this->fd, (void *)buf, 1)) != 1) {
             DASH_LOG(error) << "[ELM327] failed read";
-            this->connected = false;
-            return "";
+            if(adapterType != BT)
+            {
+                this->connected = false;
+                return "";
+            }
+            else
+            {
+                continue;
+            }
         }
         if (buf[0] == '>')
             break;

--- a/src/canbus/elm327.cpp
+++ b/src/canbus/elm327.cpp
@@ -9,6 +9,7 @@ elm327::elm327(QString canInterface, bool bluetooth)
         QObject::connect(btSocket, &QBluetoothSocket::connected, this, &elm327::btConnected);
         QObject::connect(btSocket, &QBluetoothSocket::stateChanged, this, &elm327::socketChanged);
         btSocket->connectToService(QBluetoothAddress(canInterface), QBluetoothUuid(QString("00001101-0000-1000-8000-00805F9B34FB")), QIODevice::ReadWrite);
+        bluetooth_watchdog = new QTimer(this);
     }
     else{
         this->connect(canInterface, B115200);
@@ -212,7 +213,6 @@ std::string elm327::_read()
     char buf[1];
     std::string str;
     
-    QTimer* bluetooth_watchdog = new QTimer(this);
     if(adapterType==BT)
         bluetooth_watchdog->start(5000);
 


### PR DESCRIPTION
Configured through vehicle page settings - can select any paired BT device.

Adapter must be connected to the pi for this to work - no autoconnect functionality rn.