### PR TITLE
delete method from arbiter which  no longer exists

### DIFF
--- a/include/app/arbiter.hpp
+++ b/include/app/arbiter.hpp
@@ -44,7 +44,6 @@ class Arbiter : public QObject {
     void increase_volume(uint8_t val);
     void set_cursor(bool enabled);
     void set_action(Action *action, QString key);
-    void send_openauto_button_press(aasdk::proto::enums::ButtonCode::Enum buttonCode, openauto::projection::WheelDirection wheelDirection = openauto::projection::WheelDirection::NONE);
 
     QMainWindow *window();
     QSettings &settings() { return this->session_.settings_; }


### PR DESCRIPTION
## Description:

function  send_openauto_button_press  was deleted from arbiter.cpp, but still present in arbiter.hpp

This confuses, in my case I used it in plugin, and it compiled fine, but app crashed when I tried to invoke it :(