### PR TITLE
Add initial nix build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /lib
 /nbproject
 /cmake-build-debug
+/result
 
 # Compiled source #
 ###################

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1707092692,
+        "narHash": "sha256-ZbHsm+mGk/izkWtT4xwwqz38fdlwu7nUUKXTOmm4SyE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "faf912b086576fd1a15fca610166c98d47bc667e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
             h264bitstream
             openDsh_aasdk
             openDsh_dash
+            openDsh_dash_nonnixos
             openDsh_openauto
             qtGStreamer
             ;

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "OpenDash is a Qt-based infotainment center for your Linux OpenAuto installation!";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs, ... }:
+    let
+      inherit (nixpkgs) lib;
+
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = f: lib.genAttrs systems (system: f system);
+
+      pkgsWithOverlay = forAllSystems (
+        system:
+        import nixpkgs {
+          localSystem = system;
+          overlays = [ self.overlays.openDsh-packages ];
+        }
+      );
+    in
+    {
+      overlays = import ./nix/overlays.nix { inherit self lib; };
+
+      packages = forAllSystems (
+        system: {
+          default = self.packages.${system}.openDsh_dash;
+          inherit (pkgsWithOverlay.${system})
+            h264bitstream
+            openDsh_aasdk
+            openDsh_dash
+            openDsh_openauto
+            qtGStreamer
+            ;
+        }
+      );
+
+      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-rfc-style);
+    };
+}

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -1,0 +1,22 @@
+{ lib, self }:
+{
+  default = lib.composeManyExtensions (with self.overlays; [ openDsh-packages ]);
+
+  openDsh-packages = lib.composeManyExtensions [
+    (
+      final: prev:
+      let
+        packages = final.callPackage ./pkgs { inherit self; };
+      in
+      {
+        inherit (packages)
+          openDsh_aasdk
+          openDsh_dash
+          openDsh_openauto
+          h264bitstream
+          qtGStreamer
+          ;
+      }
+    )
+  ];
+}

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -12,6 +12,7 @@
         inherit (packages)
           openDsh_aasdk
           openDsh_dash
+          openDsh_dash_nonnixos
           openDsh_openauto
           h264bitstream
           qtGStreamer

--- a/nix/pkgs/aasdk/default.nix
+++ b/nix/pkgs/aasdk/default.nix
@@ -1,0 +1,53 @@
+{
+  boost,
+  cmake,
+  elfutils,
+  fetchFromGitHub,
+  ffmpeg,
+  glib,
+  gst_all_1,
+  gtest,
+  lib,
+  libusb,
+  openssl,
+  protobuf3_20,
+  stdenv,
+}:
+{
+  openDsh_aasdk = stdenv.mkDerivation {
+    pname = "openDsh_aasdk";
+    version = "unstable-2024-02-06";
+
+    src = fetchFromGitHub {
+      owner = "openDsh";
+      repo = "aasdk";
+      rev = "1bc0fe69d5f5f505c978a0c6e32c860e820fa8f6";
+      hash = "sha256-Gqd+IHn3G3yU1/SSrp8B+isn1mhsGj2w41oMmSgkpQY=";
+    };
+
+    outputs = [
+      "dev"
+      "out"
+    ];
+
+    cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
+
+    patches = [ ../../../patches/aasdk_openssl-fips-fix.patch ];
+
+    buildInputs = [
+      boost
+      libusb
+      protobuf3_20
+      openssl
+      gtest
+    ];
+    nativeBuildInputs = [ cmake ];
+
+    meta = with lib; {
+      homepage = "https://github.com/openDsh/aasdk";
+      description = "Library containing implementation of core AndroidAuto(tm) functionalities";
+      license = licenses.gpl3;
+      platforms = with platforms; intersectLists linux (aarch64 ++ x86_64);
+    };
+  };
+}

--- a/nix/pkgs/dash/default.nix
+++ b/nix/pkgs/dash/default.nix
@@ -1,0 +1,90 @@
+{
+  boost,
+  cmake,
+  gst_all_1,
+  lib,
+  libsForQt5,
+  libusb,
+  openDsh_aasdk,
+  openDsh_openauto,
+  openssl,
+  pkg-config,
+  protobuf3_20,
+  qt5,
+  qtGStreamer,
+  rtaudio,
+  stdenv,
+  taglib,
+  date,
+}:
+{
+  openDsh_dash = stdenv.mkDerivation {
+    pname = "openDsh_dash";
+    version = "${date}";
+    src =
+      let
+        sourceFilter =
+          name: type:
+          let
+            baseName = baseNameOf (toString name);
+          in
+          !(
+            (baseName == "patches" && type == "directory")
+            || (lib.hasSuffix ".nix" baseName)
+            || baseName == "flake.lock"
+            || baseName == "install.sh"
+            || baseName == "rpi.sh"
+          );
+      in
+      lib.cleanSourceWith {
+        filter = sourceFilter;
+        src = lib.cleanSource ../../../.;
+      };
+
+    # This project may consume a significant amount of memory during compilation.
+    enableParallelBuilding = false;
+
+    cmakeFlags = [ "-DGST_BUILD=TRUE" ];
+
+    postInstall = ''
+      qtWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")
+      qtWrapperArgs+=(--prefix 'NIXPKGS_QT5_QML_IMPORT_PATH' ':' '${qtGStreamer}/lib/qt5/qml')
+    '';
+
+    nativeBuildInputs = [
+      cmake
+      pkg-config
+      qt5.wrapQtAppsHook
+    ];
+    buildInputs = [
+      boost
+      libusb
+      qt5.full
+      qt5.qtserialbus
+      libsForQt5.bluez-qt
+      protobuf3_20
+      openssl
+      rtaudio
+      taglib
+      openDsh_aasdk
+      openDsh_openauto
+    ];
+    propagatedBuildInputs = [
+      gst_all_1.gstreamer
+      gst_all_1.gst-plugins-base
+      gst_all_1.gst-plugins-good
+      gst_all_1.gst-plugins-bad
+      gst_all_1.gst-plugins-ugly
+      gst_all_1.gst-libav
+      qtGStreamer
+    ];
+
+    meta = with lib; {
+      homepage = "https://github.com/openDsh/dash";
+      description = "A Qt-based infotainment center for your Linux OpenAuto installation!";
+      license = licenses.gpl3;
+      platforms = with platforms; intersectLists linux (aarch64 ++ x86_64);
+      mainProgram = "dash";
+    };
+  };
+}

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  pkgs,
+  self,
+}:
+let
+  mkDate =
+    longDate:
+    (lib.concatStringsSep "-" [
+      (builtins.substring 0 4 longDate)
+      (builtins.substring 4 2 longDate)
+      (builtins.substring 6 2 longDate)
+    ]);
+in
+{
+  inherit (pkgs.callPackage ./h264bitstream { }) h264bitstream;
+  inherit (pkgs.callPackage ./qtgstreamer { }) qtGStreamer;
+  inherit (pkgs.callPackage ./aasdk { }) openDsh_aasdk;
+  inherit (pkgs.callPackage ./openauto { }) openDsh_openauto;
+  inherit (pkgs.callPackage ./dash { date = (mkDate self.lastModifiedDate); }) openDsh_dash;
+}

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -17,5 +17,5 @@ in
   inherit (pkgs.callPackage ./qtgstreamer { }) qtGStreamer;
   inherit (pkgs.callPackage ./aasdk { }) openDsh_aasdk;
   inherit (pkgs.callPackage ./openauto { }) openDsh_openauto;
-  inherit (pkgs.callPackage ./dash { date = (mkDate self.lastModifiedDate); }) openDsh_dash;
+  inherit (pkgs.callPackage ./dash { date = (mkDate self.lastModifiedDate); }) openDsh_dash openDsh_dash_nonnixos;
 }

--- a/nix/pkgs/h264bitstream/default.nix
+++ b/nix/pkgs/h264bitstream/default.nix
@@ -1,0 +1,39 @@
+{
+  cmake,
+  fetchFromGitHub,
+  ffmpeg,
+  lib,
+  stdenv,
+}:
+{
+  h264bitstream = stdenv.mkDerivation rec {
+    pname = "h264bitstream";
+    version = "dev-${src.rev}";
+
+    src = fetchFromGitHub {
+      owner = "aizvorski";
+      repo = "h264bitstream";
+      rev = "ae72f7395f328876199a7e928d3b4a6dc6a7ce14";
+      hash = "sha256-V96hO97PNxq7FHhr/Sk3cAvtXD30MO4LlL9M/OZ3H18=";
+    };
+    patches = [ ../../../patches/h264bitstream_path_patch_fixup.patch ];
+
+    outputs = [
+      "out"
+      "dev"
+    ];
+    buildInputs = [ ffmpeg ];
+    nativeBuildInputs = [ cmake ];
+    postInstall = ''
+      install -d $out/lib/pkgconfig/
+      install libh264bitstream.pc $out/lib/pkgconfig/libh264bitstream.pc
+    '';
+
+    meta = with lib; {
+      homepage = "https://github.com/aizvorski/h264bitstream";
+      description = "A complete set of functions to read and write H.264 video bitstreams, in particular to examine or modify headers.";
+      license = licenses.lgpl21;
+      platforms = with platforms; intersectLists linux (aarch64 ++ x86_64);
+    };
+  };
+}

--- a/nix/pkgs/openauto/default.nix
+++ b/nix/pkgs/openauto/default.nix
@@ -1,0 +1,92 @@
+{
+  boost,
+  cmake,
+  elfutils,
+  fetchFromGitHub,
+  ffmpeg,
+  glib,
+  gst_all_1,
+  gtest,
+  h264bitstream,
+  lib,
+  libusb,
+  openssl,
+  openDsh_aasdk,
+  pcre2,
+  pkg-config,
+  protobuf3_20,
+  qt5,
+  qtGStreamer,
+  rtaudio,
+  stdenv,
+}:
+{
+  openDsh_openauto = stdenv.mkDerivation rec {
+    pname = "openDsh_openauto";
+    version = "dev-${src.rev}";
+
+    src = fetchFromGitHub {
+      owner = "openDsh";
+      repo = "openauto";
+      rev = "6496f8e360b54e2c22c55edcb0757f46865294dd";
+      hash = "sha256-kEqKJMWC5tI2WC45CF1fGJbr15PjGQlVKgp2YXzyRb4=";
+    };
+
+    patches = [
+      ../../../patches/openauto_find-h264bitstream.patch
+      ../../../patches/openauto_rpath-for-nix.patch
+    ];
+
+    # This project build is too heavy to parallel on a Pi4-4GB.
+    enableParallelBuilding = false;
+
+    cmakeFlags = [
+      "-DCMAKE_BUILD_TYPE=Release"
+      ''-DAASDK_INCLUDE_DIR="${openDsh_aasdk.dev}/include"''
+      "-DGST_BUILD=TRUE" # GST_BUILD or # RPI_BUILD
+    ];
+    nativeBuildInputs = [
+      cmake
+      pkg-config
+      qt5.wrapQtAppsHook
+    ];
+    buildInputs = [
+      openDsh_aasdk
+      boost
+      libusb
+      openssl
+      pcre2
+      protobuf3_20
+      qt5.full
+      rtaudio
+      # FIXME: Add option to toggle RPi target.
+      # OMX IL Headers exist in libraspberrypi
+      # ilclient is not pre-compiled there.
+      # Not useful for RPi4, only RPi3.
+      h264bitstream
+    ];
+
+    propagatedBuildInputs = [
+      gst_all_1.gstreamer
+      gst_all_1.gst-plugins-base
+      gst_all_1.gst-plugins-good
+      gst_all_1.gst-plugins-bad
+      gst_all_1.gst-plugins-ugly
+      gst_all_1.gst-libav
+      qtGStreamer
+    ];
+
+    postInstall = ''
+      qtWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")
+      qtWrapperArgs+=(--prefix 'NIXPKGS_QT5_QML_IMPORT_PATH' ':' '${qtGStreamer}/lib/qt5/qml')
+    '';
+
+    meta = with lib; {
+      homepage = "https://github.com/openDsh/openauto";
+      description = "OpenAuto is an AndroidAuto(tm) headunit emulator based on aasdk library and Qt libraries";
+      license = licenses.gpl3;
+      platforms = with platforms; intersectLists linux (aarch64 ++ x86_64);
+      mainProgram = "autoapp";
+    };
+  };
+}

--- a/nix/pkgs/qtgstreamer/default.nix
+++ b/nix/pkgs/qtgstreamer/default.nix
@@ -1,0 +1,78 @@
+{
+  boost,
+  cmake,
+  elfutils,
+  fetchFromGitHub,
+  glib,
+  gst_all_1,
+  lib,
+  libunwind,
+  orc,
+  pcre2,
+  pkg-config,
+  qt5,
+  stdenv,
+  zstd,
+}:
+{
+  qtGStreamer = stdenv.mkDerivation rec {
+    pname = "qt-gstreamer";
+    version = "dev-${src.rev}";
+
+    src = fetchFromGitHub {
+      owner = "GStreamer";
+      repo = "qt-gstreamer";
+      rev = "6e4fb2f3fcfb453c5522c66457ac5ed8c3b1b05c";
+      hash = "sha256-4re3LDZS0NNeC2800J4TJ5SsI/b7MtdElwWcOPEYftU=";
+    };
+
+    patches = [
+      ../../../patches/qt-gstreamer_atomic-load.patch
+      ../../../patches/qt-gstreamer_pc_path.patch
+      ../../../patches/qt-gstreamer-1.18.patch
+      ../../../patches/greenline_fix.patch
+    ];
+
+    outputs = [
+      "out"
+      "dev"
+    ];
+
+    cmakeFlags = [
+      "-DQT_VERSION=5"
+      "-DCMAKE_CXX_FLAGS=-std=c++11"
+      "-DUSE_GST_PLUGIN_DIR=OFF"
+      "-DUSE_QT_PLUGIN_DIR=OFF"
+    ];
+
+    buildInputs = [
+      boost
+      elfutils
+      glib
+      gst_all_1.gstreamer
+      gst_all_1.gst-plugins-base
+      gst_all_1.gst-plugins-good
+      gst_all_1.gst-plugins-ugly
+      gst_all_1.gst-plugins-bad
+      gst_all_1.gst-libav
+      libunwind
+      orc
+      pcre2
+      qt5.full
+      qt5.qtdeclarative
+      zstd
+    ];
+    nativeBuildInputs = [
+      cmake
+      pkg-config
+      qt5.wrapQtAppsHook
+    ];
+
+    meta = with lib; {
+      homepage = "https://github.com/aizvorski/h264bitstream";
+      description = "A complete set of functions to read and write H.264 video bitstreams, in particular to examine or modify headers.";
+      license = licenses.lgpl21;
+      platforms = platforms.all;
+    };
+  };
+}

--- a/patches/h264bitstream_path_patch_fixup.patch
+++ b/patches/h264bitstream_path_patch_fixup.patch
@@ -1,0 +1,36 @@
+We need the pkgconfig to point at the installed location, not somewhere
+in the build directory.
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9419cb6..e738bff 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -68,9 +68,10 @@ if(UNIX)
+ 
+ 	configure_file("${CMAKE_CURRENT_SOURCE_DIR}/libh264bitstream.pc.in"
+ 		"${CMAKE_CURRENT_BINARY_DIR}/libh264bitstream.pc"
++		@ONLY
+ 	)
+ 
+ 	install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libh264bitstream.pc"
+ 		DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig"
+ 	)
+-endif(UNIX)
+\ No newline at end of file
++endif(UNIX)
+diff --git a/libh264bitstream.pc.in b/libh264bitstream.pc.in
+index 3211162..7a9ccc3 100644
+--- a/libh264bitstream.pc.in
++++ b/libh264bitstream.pc.in
+@@ -1,7 +1,7 @@
+-prefix=@prefix@
+-exec_prefix=@exec_prefix@
+-libdir=@libdir@
+-includedir=@includedir@
++prefix=@CMAKE_INSTALL_PREFIX@
++exec_prefix=${prefix}
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
++includedir=@CMAKE_INSTALL_INCLUDEDIR@
+ 
+ Name: @PROJECT_NAME@
+ Description: @PROJECT_DESCRIPTION@

--- a/patches/openauto_find-h264bitstream.patch
+++ b/patches/openauto_find-h264bitstream.patch
@@ -1,0 +1,25 @@
+It is installed properly, use pkg-config to find it.  It will not have a
+static path on nix as it will reside in the nix store, and that path depends
+on the complete closure of its derivation.
+
+diff --git a/cmake_modules/Findh264.cmake b/cmake_modules/Findh264.cmake
+index 0f9bffd..fa2b537 100644
+--- a/cmake_modules/Findh264.cmake
++++ b/cmake_modules/Findh264.cmake
+@@ -1,5 +1,14 @@
+-set (H264_INCLUDE_DIR /usr/local/include/h264bitstream)
+-set (H264_LIB_DIR /usr/local/lib)
++find_path(H264_INCLUDE_DIR
++    h264_avcc.h
++    PATHS ${H264_DIR}
++    PATH_SUFFIXES include
++)
++
++find_path(H264_LIB_DIR
++    libh264bitstream.a
++    PATHS ${H264_DIR}
++    PATH_SUFFIXES lib
++)
+ 
+ set(H264_FOUND TRUE)
+   

--- a/patches/openauto_rpath-for-nix.patch
+++ b/patches/openauto_rpath-for-nix.patch
@@ -1,0 +1,45 @@
+I give up, I don't knwo why cmake is not fixing rpath on the libs during the
+install phase.  This makes nix very angry, because a reference to /build/...
+is not right.  Tell cmake to build with install RPATH as I can't work out why
+it's not fixing up correctly.  It works fine in a dev shell during install phase.
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index da2af6b..db6c36d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -17,7 +17,8 @@ set(CMAKE_AUTOMOC ON)
+ set(CMAKE_AUTOUIC ON)
+ set(CMAKE_AUTORCC ON)
+ 
+-set(base_directory ${CMAKE_CURRENT_SOURCE_DIR})					   
++set( CMAKE_BUILD_WITH_INSTALL_RPATH TRUE )
++set(base_directory ${CMAKE_CURRENT_SOURCE_DIR})
+ set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
+ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+diff --git a/autoapp/CMakeLists.txt b/autoapp/CMakeLists.txt
+index 67946c8..0050c52 100644
+--- a/autoapp/CMakeLists.txt
++++ b/autoapp/CMakeLists.txt
+@@ -26,7 +26,7 @@ if(RPI_BUILD AND NOT GST_BUILD)
+ endif()
+ 
+ set_target_properties(autoapp
+-        PROPERTIES INSTALL_RPATH_USE_LINK_PATH 1)
++        PROPERTIES INSTALL_RPATH_USE_LINK_PATH 0)
+ 
+ install(TARGETS autoapp
+         RUNTIME DESTINATION bin)
+diff --git a/openauto/CMakeLists.txt b/openauto/CMakeLists.txt
+index 8f2238a..b1dd2f7 100644
+--- a/openauto/CMakeLists.txt
++++ b/openauto/CMakeLists.txt
+@@ -127,7 +127,7 @@ install(TARGETS openauto
+         LIBRARY DESTINATION lib)
+ 
+ set_target_properties(openauto
+-        PROPERTIES INSTALL_RPATH_USE_LINK_PATH 1)
++        PROPERTIES INSTALL_RPATH_USE_LINK_PATH 0)
+ 
+ install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/openauto DESTINATION include)
+ install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/btservice DESTINATION include)

--- a/patches/qt-gstreamer_pc_path.patch
+++ b/patches/qt-gstreamer_pc_path.patch
@@ -1,0 +1,72 @@
+See: https://github.com/NixOS/nixpkgs/issues/144170
+
+diff --git a/src/QGlib/QtGLib-2.0.pc.in b/src/QGlib/QtGLib-2.0.pc.in
+index 96dac7c..2724e7a 100644
+--- a/src/QGlib/QtGLib-2.0.pc.in
++++ b/src/QGlib/QtGLib-2.0.pc.in
+@@ -1,7 +1,7 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@QTGSTREAMER_INCLUDES_INSTALL_DIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
++includedir=@QTGSTREAMER_INCLUDES_INSTALL_DIR@
+ 
+ Name: @QTGLIB_LIBRARY@-2.0
+ Description: Qt-style C++ bindings library for GLib & GObject
+diff --git a/src/QGst/QtGStreamer-1.0.pc.in b/src/QGst/QtGStreamer-1.0.pc.in
+index d6fabc6..9926379 100644
+--- a/src/QGst/QtGStreamer-1.0.pc.in
++++ b/src/QGst/QtGStreamer-1.0.pc.in
+@@ -1,7 +1,7 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@QTGSTREAMER_INCLUDES_INSTALL_DIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
++includedir=@QTGSTREAMER_INCLUDES_INSTALL_DIR@
+ 
+ Name: @QTGSTREAMER_LIBRARY@-1.0
+ Description: Qt-style C++ bindings library for GStreamer
+diff --git a/src/QGst/QtGStreamerQuick-1.0.pc.in b/src/QGst/QtGStreamerQuick-1.0.pc.in
+index 21ca0ec..89d4ca4 100644
+--- a/src/QGst/QtGStreamerQuick-1.0.pc.in
++++ b/src/QGst/QtGStreamerQuick-1.0.pc.in
+@@ -1,7 +1,7 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@QTGSTREAMER_INCLUDES_INSTALL_DIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
++includedir=@QTGSTREAMER_INCLUDES_INSTALL_DIR@
+ 
+ Name: @QTGSTREAMER_QUICK_LIBRARY@-1.0
+ Description: QtQuick GStreamer integration library
+diff --git a/src/QGst/QtGStreamerUi-1.0.pc.in b/src/QGst/QtGStreamerUi-1.0.pc.in
+index fb62189..831c70e 100644
+--- a/src/QGst/QtGStreamerUi-1.0.pc.in
++++ b/src/QGst/QtGStreamerUi-1.0.pc.in
+@@ -1,7 +1,7 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@QTGSTREAMER_INCLUDES_INSTALL_DIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
++includedir=@QTGSTREAMER_INCLUDES_INSTALL_DIR@
+ 
+ Name: @QTGSTREAMER_UI_LIBRARY@-1.0
+ Description: QtGui/QtWidgets GStreamer integration library
+diff --git a/src/QGst/QtGStreamerUtils-1.0.pc.in b/src/QGst/QtGStreamerUtils-1.0.pc.in
+index 96965ee..26cbc16 100644
+--- a/src/QGst/QtGStreamerUtils-1.0.pc.in
++++ b/src/QGst/QtGStreamerUtils-1.0.pc.in
+@@ -1,7 +1,7 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@QTGSTREAMER_INCLUDES_INSTALL_DIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
++includedir=@QTGSTREAMER_INCLUDES_INSTALL_DIR@
+ 
+ Name: @QTGSTREAMER_UTILS_LIBRARY@-1.0
+ Description: QtGStreamer's high level utility classes


### PR DESCRIPTION
I'm not sure why install.sh builds bluez from source rather than taking the system packaged one, but it's a good example of one of the ways nix will be really useful here.  If we needed to change bluez, we can do so without conflicting with the system bluez that is installed.
The same goes for OpenSSL.  While I've elected to take a patch to allow the use of the latest OpenSSL, the references to OpenSSL could easily be changed from `openssl` to `openssl_3_0`.
Protobuf is pinned, as newer version require building with C++ 17 or greater by editing CMakeLists.txt 
 to contain `SET(CMAKE_CXX_STANDARD 17)`.

Currently, this lacks a devShell, and I'd like to leave that for a future followup as it's not something I have much experience with currently.  Build environments for individual packages can be realised by requesting one for the package in question.  `nix develop -L .#packages.<SYSTEM>.<PACKAGE>`, and is mostly useful to run through nix build phases, rather than being a generic dev environment.

Dash can be built on x86_64 with, `nix build -L .#packages.x86_64-linux.openDsh_dash_nonnixos`, and a symlink to the store location will be at `./result`.

It might make since to move the package declarations of aasdk and openauto to the respective packages as it would likely make overriding them locally easier as it would be possible to pass --override-input with a path during `nix flake lock`, but that also complicates the handling of qtgstreamer and h264bitstream, and makes it more difficult to see how this all works together, so it's probably also better as a change to be made when that added complexity comes with a clear benefit.

For non-NixOS, openDsh_dash_nonnixos is the package to use as it's a script that is wrapping the dash executable to include opengl drivers from nixpkgs.
I tested this with the latest Raspberry Pi OS (bookworm) on a RPi4 4GB, and launched dash from a Sway (Wayland) environment.