### PR TITLE
Raspberry Pi 7" display brightness fix

### DIFF
--- a/plugins/brightness/official_rpi/official_rpi.cpp
+++ b/plugins/brightness/official_rpi/official_rpi.cpp
@@ -4,7 +4,16 @@
 
 OfficialRPi::OfficialRPi() : brightness_attribute(this->PATH)
 {
-    this->brightness_attribute.open(QIODevice::WriteOnly);
+    QString fkms_path = "/sys/class/backlight/rpi_backlight/brightness";
+    QString kms_path = "/sys/class/backlight/10-0045/brightness";
+ 
+    if (QFileInfo(kms_path).exists()) {
+        PATH = kms_path;
+    } else {
+        PATH = fkms_path;
+    }
+    brightness_attribute.setFileName(PATH);
+    brightness_attribute.open(QIODevice::WriteOnly);
 }
 
 OfficialRPi::~OfficialRPi()

--- a/plugins/brightness/official_rpi/official_rpi.hpp
+++ b/plugins/brightness/official_rpi/official_rpi.hpp
@@ -19,7 +19,7 @@ class OfficialRPi : public QObject, BrightnessPlugin {
     void set(int brightness) override;
 
    private:
-    const QString PATH = "/sys/class/backlight/rpi_backlight/brightness";
+    QString PATH;
 
     QFile brightness_attribute;
 };


### PR DESCRIPTION
### Brightness path:
Raspberry Pi's official DSI-based display will present itself differently when the unit is using the `vc4-kms-v3d` driver. This breaks the backlight level control provided with the dash brightness plugin. To replicate, set in `/boot/firmware/config.txt` and observe path:

`dtoverlay=vc4-fkms-v3d`       - /sys/class/backlight/rpi_backlight/brightness
`dtoverlay=vc4-kms-v3d`        - /sys/class/backlight/10-0045/brightness

This PR fixes the path by checking for one and using the other if it doesn't exist.

It's worth noting that the DSI display [seems to have trouble](https://forums.raspberrypi.com/viewtopic.php?t=305690) with the kms driver unless `dtoverlay=vc4-kms-dsi-7inch` is also loaded. I use the fkms fallback and it seems to works fine without hardware encoding. Also worth noting the existing RPi udev brightness permission works for both cases (`/sys/class/backlight/%k/brightness`)

### Brightness range:
I noticed that the display's brightness range is rather odd, the brightest value is actually 200 while maximum value 255 is slightly dimmer. Plus, steps are much more pronounced between 0-100 as they are between 100-200. Someone made [a comment about it ages ago](https://forums.raspberrypi.com/viewtopic.php?p=1343670#p1343670), and about the energy draw as well. 

I adjusted the min and max values from 76-255 to 20-180 (imperceptible from 200) and the step change to 20 units. However, I realize after posting the commit that this particular range affects *all* brightness operations using `Session::System::Brightness`, not just for the specific RPi display. Posting for review regardless, I may separate the range fix into it's own PR while seeing if it can be narrowed to only this panel. 

**Related issue (if applicable):** fixes #<issue number goes here>
https://github.com/openDsh/dash/issues/149